### PR TITLE
feat: add SimulationConfig record and eliminate magic numbers

### DIFF
--- a/Config/SimulationConfig.cs
+++ b/Config/SimulationConfig.cs
@@ -1,0 +1,23 @@
+namespace UglyClient.Config;
+
+/// <summary>
+/// Holds all configuration values for the simulation client, eliminating magic numbers
+/// and hardcoded strings from the rest of the codebase.
+/// </summary>
+/// <remarks>
+/// A single instance is constructed in <c>Program.Main</c> and passed down to every
+/// service that needs it. When service classes are extracted (issues #3, #4, #5) they
+/// should accept this record via constructor injection.
+/// </remarks>
+/// <param name="FanCount">Total number of fans managed by the simulation.</param>
+/// <param name="HeaterCount">Total number of heaters managed by the simulation.</param>
+/// <param name="SensorCount">Total number of temperature sensors managed by the simulation.</param>
+/// <param name="BaseUrl">Base URL of the environment simulation API (including trailing slash).</param>
+/// <param name="ApiKey">API key sent in the <c>X-Api-Key</c> request header.</param>
+public record SimulationConfig(
+    int FanCount,
+    int HeaterCount,
+    int SensorCount,
+    string BaseUrl,
+    string ApiKey
+);

--- a/Models/FanDTO.cs
+++ b/Models/FanDTO.cs
@@ -1,0 +1,19 @@
+namespace UglyClient.Models;
+
+/// <summary>
+/// Data Transfer Object representing the state of a fan device as returned by the
+/// <c>GET api/fans/{id}/state</c> endpoint.
+/// </summary>
+public class FanDTO
+{
+    /// <summary>
+    /// Gets or sets the unique identifier of the fan.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the fan is currently switched on.
+    /// <c>true</c> means the fan is on; <c>false</c> means the fan is off.
+    /// </summary>
+    public bool IsOn { get; set; }
+}

--- a/Models/HeaterDTO.cs
+++ b/Models/HeaterDTO.cs
@@ -1,0 +1,19 @@
+namespace UglyClient.Models;
+
+/// <summary>
+/// Data Transfer Object representing the state of a heater device as returned by the
+/// <c>GET api/heat/{id}/level</c> endpoint.
+/// </summary>
+public class HeaterDTO
+{
+    /// <summary>
+    /// Gets or sets the unique identifier of the heater.
+    /// </summary>
+    public int Id { get; set; }
+
+    /// <summary>
+    /// Gets or sets the current heat level of the heater.
+    /// The integer value corresponds to the power level reported by the API.
+    /// </summary>
+    public int Level { get; set; }
+}

--- a/Models/SensorReading.cs
+++ b/Models/SensorReading.cs
@@ -1,0 +1,21 @@
+namespace UglyClient.Models;
+
+/// <summary>
+/// Represents a normalised temperature reading from any sensor device.
+/// The API may return temperatures as <c>string</c>, <c>int</c>, or <c>decimal</c> depending on
+/// the sensor; <see cref="Temperature"/> is always stored as <c>double</c> after normalisation
+/// by <c>SensorService</c>.
+/// </summary>
+public class SensorReading
+{
+    /// <summary>
+    /// Gets or sets the unique identifier of the sensor that produced this reading.
+    /// </summary>
+    public int SensorId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the temperature value recorded by the sensor, expressed in degrees Celsius
+    /// and normalised to <c>double</c> regardless of the raw API response type.
+    /// </summary>
+    public double Temperature { get; set; }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
+using UglyClient.Models;
 
 class Program
 {
@@ -580,11 +581,5 @@ class Program
         }
     }
 
-
-    public class FanDTO
-    {
-        public int Id { get; set; }
-        public bool IsOn { get; set; }
-    }
 
 }

--- a/Program.cs
+++ b/Program.cs
@@ -2,21 +2,28 @@
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
+using UglyClient.Config;
 using UglyClient.Models;
 
 class Program
 {
     static async Task Main(string[] args)
     {
+        var config = new SimulationConfig(
+            FanCount: 3,
+            HeaterCount: 3,
+            SensorCount: 3,
+            BaseUrl: "https://localhost:44351/",
+            ApiKey: "u007-key"
+        );
+
         // https://envrosym.azurewebsites.net/
-        var client = new HttpClient { BaseAddress = new Uri("https://localhost:44351/") };
+        var client = new HttpClient { BaseAddress = new Uri(config.BaseUrl) };
         // var client = new HttpClient { BaseAddress = new Uri("https://envrosym.azurewebsites.net/") };
 
         // Must match the API key in ApiKeyManager (dictionary key)
         // MUST match a DICTIONARY KEY on the server:
-        const string apiKey = "u007-key";
-
-        client.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+        client.DefaultRequestHeaders.Add("X-Api-Key", config.ApiKey);
 
         while (true)
         {
@@ -110,7 +117,7 @@ class Program
                     try
                     {
                         Console.WriteLine("Fetching fan states individually...");
-                        for (int i = 1; i <= 3; i++) // Assuming there are 3 fans for this example
+                        for (int i = 1; i <= config.FanCount; i++)
                         {
                             var fanResponse = await client.GetAsync($"api/fans/{i}/state");
                             if (fanResponse.IsSuccessStatusCode)
@@ -128,7 +135,7 @@ class Program
                             }
                         }
                         Console.WriteLine("Fetching heater levels individually...");
-                        for (int i = 1; i <= 3; i++) // Assuming there are 3 heaters for this example
+                        for (int i = 1; i <= config.HeaterCount; i++)
                         {
                             var heaterResponse = await client.GetAsync($"api/heat/{i}/level");
                             if (heaterResponse.IsSuccessStatusCode)
@@ -208,7 +215,7 @@ class Program
                             {
                                 // Get individual fan states
                                 Console.WriteLine("Fetching fan states individually...");
-                                for (int i = 1; i <= 3; i++) // Assuming there are 3 fans for this example
+                                for (int i = 1; i <= config.FanCount; i++)
                                 {
                                     var fanResponse = await client.GetAsync($"api/fans/{i}/state");
                                     if (fanResponse.IsSuccessStatusCode)
@@ -228,7 +235,7 @@ class Program
 
                                 // Get individual heater levels
                                 Console.WriteLine("Fetching heater levels individually...");
-                                for (int i = 1; i <= 3; i++) // Assuming there are 3 heaters for this example
+                                for (int i = 1; i <= config.HeaterCount; i++)
                                 {
                                     var heaterResponse = await client.GetAsync($"api/heat/{i}/level");
                                     if (heaterResponse.IsSuccessStatusCode)
@@ -291,7 +298,7 @@ class Program
         }
     }
 
-    private static async Task Reset(HttpClient client)
+    private static async Task Reset(HttpClient client, SimulationConfig config)
     {
         Console.WriteLine("Resetting client state...");
 
@@ -309,7 +316,7 @@ class Program
                 {
                     // Get individual fan states
                     Console.WriteLine("Fetching fan states individually...");
-                    for (int i = 1; i <= 3; i++) // Assuming there are 3 fans for this example
+                    for (int i = 1; i <= config.FanCount; i++)
                     {
                         var fanResponse = await client.GetAsync($"api/fans/{i}/state");
                         if (fanResponse.IsSuccessStatusCode)
@@ -329,7 +336,7 @@ class Program
 
                     // Get individual heater levels
                     Console.WriteLine("Fetching heater levels individually...");
-                    for (int i = 1; i <= 3; i++) // Assuming there are 3 heaters for this example
+                    for (int i = 1; i <= config.HeaterCount; i++)
                     {
                         var heaterResponse = await client.GetAsync($"api/heat/{i}/level");
                         if (heaterResponse.IsSuccessStatusCode)


### PR DESCRIPTION
## Summary

Closes #14

Introduces `SimulationConfig` to eliminate every magic number, hardcoded URL, and hardcoded API key from `Program.cs`.

## Changes

### `Config/SimulationConfig.cs` (new)
- Defines `SimulationConfig` record in the `UglyClient.Config` namespace
- Full XML documentation on the record and every parameter
- Properties: `FanCount`, `HeaterCount`, `SensorCount`, `BaseUrl`, `ApiKey`
- Designed for constructor injection into future service classes (issues #3, #4, #5)

### `Program.cs` (updated)
- Adds `using UglyClient.Config;`
- Constructs a single `SimulationConfig` instance at the top of `Main` with current values:
  - `FanCount = 3`, `HeaterCount = 3`, `SensorCount = 3`
  - `BaseUrl = "https://localhost:44351/"`
  - `ApiKey = "u007-key"`
- Replaces `new Uri("https://localhost:44351/")` → `new Uri(config.BaseUrl)`
- Replaces `const string apiKey = "u007-key"` and its usage → `config.ApiKey`
- Replaces `<= 3` bounds in:
  - `Main` case `"4"` fan and heater loops
  - `Main` case `"6"` fan and heater loops
  - Private `Reset` method fan and heater loops
- `SetAllHeaters` and `SetAllFans` static helpers intentionally left unchanged — they will be removed when service classes land in #3, #4, #5

## Acceptance criteria

- [x] `SimulationConfig` record in `Config/`
- [x] No magic numbers remaining in any class (except `SetAllHeaters`/`SetAllFans` which are pending removal)
- [x] No hardcoded base URL or API key outside `Program.cs` construction site
- [x] Config values injected throughout `Program.cs` loops

## Build
`dotnet build` passes — 0 errors, 3 pre-existing CS8602 warnings (null dereference on `fan.Id`) unrelated to this change.