### PR TITLE
feat: implement ISensor Adapter Pattern to unify sensor temperature methods (#2)

### DIFF
--- a/Adapters/Sensor1Adapter.cs
+++ b/Adapters/Sensor1Adapter.cs
@@ -1,0 +1,57 @@
+using UglyClient.Interfaces;
+
+namespace UglyClient.Adapters;
+
+/// <summary>
+/// Adapter that wraps the Sensor 1 HTTP endpoint and converts its raw <see cref="string"/>
+/// response into a <see cref="double"/> temperature value, conforming to <see cref="ISensor"/>.
+/// </summary>
+/// <remarks>
+/// Sensor 1 returns its reading as a plain text string (e.g. <c>"21.5"</c>).
+/// This adapter parses that string with <see cref="double.Parse(string)"/> so that
+/// callers never need to know the underlying representation.
+/// </remarks>
+public sealed class Sensor1Adapter : ISensor
+{
+    /// <summary>The shared <see cref="HttpClient"/> used to make requests to the sensor API.</summary>
+    private readonly HttpClient _client;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="Sensor1Adapter"/>.
+    /// </summary>
+    /// <param name="client">
+    /// The <see cref="HttpClient"/> pre-configured with the base address and any
+    /// required authentication headers.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="client"/> is <see langword="null"/>.
+    /// </exception>
+    public Sensor1Adapter(HttpClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Calls <c>GET api/Sensor/sensor1</c>. The API returns the temperature as a
+    /// plain <see cref="string"/> which is parsed to <see cref="double"/>.
+    /// </remarks>
+    public async Task<double> GetTemperatureAsync()
+    {
+        var response = await _client.GetAsync("api/Sensor/sensor1");
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception($"Failed to get temperature from Sensor 1: {response.ReasonPhrase}");
+        }
+
+        var content = await response.Content.ReadAsStringAsync();
+
+        if (!double.TryParse(content, out double temperature))
+        {
+            throw new Exception($"Failed to parse Sensor 1 temperature as a double. Raw value: '{content}'");
+        }
+
+        return temperature;
+    }
+}

--- a/Adapters/Sensor2Adapter.cs
+++ b/Adapters/Sensor2Adapter.cs
@@ -1,0 +1,59 @@
+using UglyClient.Interfaces;
+
+namespace UglyClient.Adapters;
+
+/// <summary>
+/// Adapter that wraps the Sensor 2 HTTP endpoint and converts its raw <see cref="int"/>
+/// response into a <see cref="double"/> temperature value, conforming to <see cref="ISensor"/>.
+/// </summary>
+/// <remarks>
+/// Sensor 2 returns its reading as a plain integer string (e.g. <c>"21"</c>).
+/// This adapter parses that integer with <see cref="int.TryParse(string, out int)"/> and
+/// widens it to <see cref="double"/> so that callers never need to know the underlying
+/// representation.
+/// </remarks>
+public sealed class Sensor2Adapter : ISensor
+{
+    /// <summary>The shared <see cref="HttpClient"/> used to make requests to the sensor API.</summary>
+    private readonly HttpClient _client;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="Sensor2Adapter"/>.
+    /// </summary>
+    /// <param name="client">
+    /// The <see cref="HttpClient"/> pre-configured with the base address and any
+    /// required authentication headers.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="client"/> is <see langword="null"/>.
+    /// </exception>
+    public Sensor2Adapter(HttpClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Calls <c>GET api/Sensor/sensor2</c>. The API returns the temperature as an
+    /// integer string which is parsed to <see cref="int"/> and then widened to
+    /// <see cref="double"/>.
+    /// </remarks>
+    public async Task<double> GetTemperatureAsync()
+    {
+        var response = await _client.GetAsync("api/Sensor/sensor2");
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception($"Failed to get temperature from Sensor 2: {response.ReasonPhrase}");
+        }
+
+        var content = await response.Content.ReadAsStringAsync();
+
+        if (!int.TryParse(content, out int temperature))
+        {
+            throw new Exception($"Failed to parse Sensor 2 temperature as an integer. Raw value: '{content}'");
+        }
+
+        return (double)temperature;
+    }
+}

--- a/Adapters/Sensor3Adapter.cs
+++ b/Adapters/Sensor3Adapter.cs
@@ -1,0 +1,59 @@
+using UglyClient.Interfaces;
+
+namespace UglyClient.Adapters;
+
+/// <summary>
+/// Adapter that wraps the Sensor 3 HTTP endpoint and converts its raw <see cref="decimal"/>
+/// response into a <see cref="double"/> temperature value, conforming to <see cref="ISensor"/>.
+/// </summary>
+/// <remarks>
+/// Sensor 3 returns its reading as a decimal string (e.g. <c>"21.75"</c>).
+/// This adapter parses that decimal with <see cref="decimal.TryParse(string, out decimal)"/>
+/// and casts it to <see cref="double"/> so that callers never need to know the underlying
+/// representation.
+/// </remarks>
+public sealed class Sensor3Adapter : ISensor
+{
+    /// <summary>The shared <see cref="HttpClient"/> used to make requests to the sensor API.</summary>
+    private readonly HttpClient _client;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="Sensor3Adapter"/>.
+    /// </summary>
+    /// <param name="client">
+    /// The <see cref="HttpClient"/> pre-configured with the base address and any
+    /// required authentication headers.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="client"/> is <see langword="null"/>.
+    /// </exception>
+    public Sensor3Adapter(HttpClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Calls <c>GET api/Sensor/sensor3</c>. The API returns the temperature as a
+    /// decimal string which is parsed to <see cref="decimal"/> and then cast to
+    /// <see cref="double"/>.
+    /// </remarks>
+    public async Task<double> GetTemperatureAsync()
+    {
+        var response = await _client.GetAsync("api/Sensor/sensor3");
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception($"Failed to get temperature from Sensor 3: {response.ReasonPhrase}");
+        }
+
+        var content = await response.Content.ReadAsStringAsync();
+
+        if (!decimal.TryParse(content, out decimal temperature))
+        {
+            throw new Exception($"Failed to parse Sensor 3 temperature as a decimal. Raw value: '{content}'");
+        }
+
+        return (double)temperature;
+    }
+}

--- a/Interfaces/ISensor.cs
+++ b/Interfaces/ISensor.cs
@@ -1,0 +1,23 @@
+namespace UglyClient.Interfaces;
+
+/// <summary>
+/// Defines the contract for a temperature sensor.
+/// Implementing this interface as part of the Adapter Pattern ensures that all
+/// sensor adapters — regardless of their underlying HTTP response format — expose
+/// a unified <see cref="GetTemperatureAsync"/> method that returns a <see cref="double"/>.
+/// </summary>
+public interface ISensor
+{
+    /// <summary>
+    /// Asynchronously retrieves the current temperature reading from the sensor.
+    /// </summary>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that resolves to the sensor temperature as a
+    /// <see cref="double"/> (degrees Celsius).
+    /// </returns>
+    /// <exception cref="Exception">
+    /// Thrown when the HTTP request fails or the response cannot be parsed into a
+    /// valid temperature value.
+    /// </exception>
+    Task<double> GetTemperatureAsync();
+}

--- a/Program.cs
+++ b/Program.cs
@@ -2,7 +2,9 @@
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
+using UglyClient.Adapters;
 using UglyClient.Config;
+using UglyClient.Interfaces;
 using UglyClient.Models;
 
 class Program
@@ -24,6 +26,13 @@ class Program
         // Must match the API key in ApiKeyManager (dictionary key)
         // MUST match a DICTIONARY KEY on the server:
         client.DefaultRequestHeaders.Add("X-Api-Key", config.ApiKey);
+
+        // Adapter Pattern: each sensor adapter wraps its own HTTP call and converts
+        // the raw response type to double, conforming to ISensor.
+        ISensor sensor1Adapter = new Sensor1Adapter(client);
+        ISensor sensor2Adapter = new Sensor2Adapter(client);
+        ISensor sensor3Adapter = new Sensor3Adapter(client);
+        ISensor[] sensorAdapters = [sensor1Adapter, sensor2Adapter, sensor3Adapter];
 
         while (true)
         {
@@ -98,8 +107,23 @@ class Program
                     {
                         try
                         {
-                            double temperature = await GetSensorTemperature(client, sensorId);
-                            Console.WriteLine($"Sensor {sensorId} Temperature: {temperature:F1}°C");
+                            ISensor? selectedAdapter = sensorId switch
+                            {
+                                1 => sensor1Adapter,
+                                2 => sensor2Adapter,
+                                3 => sensor3Adapter,
+                                _ => null
+                            };
+
+                            if (selectedAdapter is null)
+                            {
+                                Console.WriteLine($"Sensor {sensorId} not found. Valid sensors are 1, 2, or 3.");
+                            }
+                            else
+                            {
+                                double temperature = await selectedAdapter.GetTemperatureAsync();
+                                Console.WriteLine($"Sensor {sensorId} Temperature: {temperature:F1}°C");
+                            }
                         }
                         catch (Exception ex)
                         {
@@ -158,14 +182,14 @@ class Program
                         Console.WriteLine("Fetching sensor temperatures individually...");
                         try
                         {
-                            var sensor1Temp = await GetSensor1Temperature(client);
-                            Console.WriteLine($"  Sensor 1: Temperature {sensor1Temp} (Deg)");
+                            var s1Temp = await sensor1Adapter.GetTemperatureAsync();
+                            Console.WriteLine($"  Sensor 1: Temperature {s1Temp:F1} (Deg)");
 
-                            var sensor2Temp = await GetSensor2Temperature(client);
-                            Console.WriteLine($"  Sensor 2: Temperature {sensor2Temp} (Deg)");
+                            var s2Temp = await sensor2Adapter.GetTemperatureAsync();
+                            Console.WriteLine($"  Sensor 2: Temperature {s2Temp:F1} (Deg)");
 
-                            var sensor3Temp = await GetSensor3Temperature(client);
-                            Console.WriteLine($"  Sensor 3: Temperature {sensor3Temp} (Deg)");
+                            var s3Temp = await sensor3Adapter.GetTemperatureAsync();
+                            Console.WriteLine($"  Sensor 3: Temperature {s3Temp:F1} (Deg)");
                         }
                         catch (Exception ex)
                         {
@@ -181,21 +205,21 @@ class Program
                     //await RunTemperatureControlLoop(client);
                     Console.WriteLine("Starting temperature control algorithm...");
                     Console.Write("Provide a final Temp Value: ");
-                    double currentTemperature = await GetAverageTemperature(client);
+                    double currentTemperature = await GetAverageTemperature(sensorAdapters);
                     while (true)
                     {
                         // Phase 1: Gradually increase to 20°C over 30 seconds
-                        currentTemperature = await AdjustTemperature(client, currentTemperature, 20.0, 30);
+                        currentTemperature = await AdjustTemperature(client, sensorAdapters, currentTemperature, 20.0, 30);
 
                         // Phase 2: Rapidly cool to 16°C
-                        currentTemperature = await AdjustTemperature(client, currentTemperature, 16.0, 10);
+                        currentTemperature = await AdjustTemperature(client, sensorAdapters, currentTemperature, 16.0, 10);
 
                         // Phase 3: Hold at 16°C for 10 seconds
-                        currentTemperature = await HoldTemperature(client, currentTemperature, 16.0, 10);
+                        currentTemperature = await HoldTemperature(client, sensorAdapters, currentTemperature, 16.0, 10);
 
                         // Phase 4: Gradually return to 18°C and maintain
-                        currentTemperature = await AdjustTemperature(client, currentTemperature, 18.0, 20);
-                        currentTemperature = await HoldTemperature(client, currentTemperature, 18.0, int.MaxValue); // Maintain until exit
+                        currentTemperature = await AdjustTemperature(client, sensorAdapters, currentTemperature, 18.0, 20);
+                        currentTemperature = await HoldTemperature(client, sensorAdapters, currentTemperature, 18.0, int.MaxValue); // Maintain until exit
                     }
                 case "6":
                     // await Reset(client);
@@ -260,14 +284,14 @@ class Program
                                 Console.WriteLine("Fetching sensor temperatures individually...");
                                 try
                                 {
-                                    var sensor1Temp = await GetSensor1Temperature(client);
-                                    Console.WriteLine($"  Sensor 1: Temperature {sensor1Temp} (Deg)");
+                                    var s1Temp = await sensor1Adapter.GetTemperatureAsync();
+                                    Console.WriteLine($"  Sensor 1: Temperature {s1Temp:F1} (Deg)");
 
-                                    var sensor2Temp = await GetSensor2Temperature(client);
-                                    Console.WriteLine($"  Sensor 2: Temperature {sensor2Temp} (Deg)");
+                                    var s2Temp = await sensor2Adapter.GetTemperatureAsync();
+                                    Console.WriteLine($"  Sensor 2: Temperature {s2Temp:F1} (Deg)");
 
-                                    var sensor3Temp = await GetSensor3Temperature(client);
-                                    Console.WriteLine($"  Sensor 3: Temperature {sensor3Temp} (Deg)");
+                                    var s3Temp = await sensor3Adapter.GetTemperatureAsync();
+                                    Console.WriteLine($"  Sensor 3: Temperature {s3Temp:F1} (Deg)");
                                 }
                                 catch (Exception ex)
                                 {
@@ -298,7 +322,7 @@ class Program
         }
     }
 
-    private static async Task Reset(HttpClient client, SimulationConfig config)
+    private static async Task Reset(HttpClient client, SimulationConfig config, IEnumerable<ISensor> sensors)
     {
         Console.WriteLine("Resetting client state...");
 
@@ -361,14 +385,13 @@ class Program
                     Console.WriteLine("Fetching sensor temperatures individually...");
                     try
                     {
-                        var sensor1Temp = await GetSensor1Temperature(client);
-                        Console.WriteLine($"  Sensor 1: Temperature {sensor1Temp} (Deg)");
-
-                        var sensor2Temp = await GetSensor2Temperature(client);
-                        Console.WriteLine($"  Sensor 2: Temperature {sensor2Temp} (Deg)");
-
-                        var sensor3Temp = await GetSensor3Temperature(client);
-                        Console.WriteLine($"  Sensor 3: Temperature {sensor3Temp} (Deg)");
+                        int sensorIndex = 1;
+                        foreach (var sensor in sensors)
+                        {
+                            var temp = await sensor.GetTemperatureAsync();
+                            Console.WriteLine($"  Sensor {sensorIndex}: Temperature {temp:F1} (Deg)");
+                            sensorIndex++;
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -391,11 +414,11 @@ class Program
         }
     }
 
-    static async Task RunTemperatureControlLoop(HttpClient client)
+    static async Task RunTemperatureControlLoop(HttpClient client, IEnumerable<ISensor> sensors)
     {
         Console.WriteLine("Starting temperature control algorithm...");
 
-        double currentTemperature = await GetAverageTemperature(client);
+        double currentTemperature = await GetAverageTemperature(sensors);
 
         // Prompt user for the final target temperature in Phase 4
         Console.Write("Enter the final target temperature for Phase 4: ");
@@ -408,21 +431,21 @@ class Program
         while (true)
         {
             // Phase 1: Gradually increase to 20°C over 30 seconds
-            currentTemperature = await AdjustTemperature(client, currentTemperature, 20.0, 30);
+            currentTemperature = await AdjustTemperature(client, sensors, currentTemperature, 20.0, 30);
 
             // Phase 2: Rapidly cool to 16°C
-            currentTemperature = await AdjustTemperature(client, currentTemperature, 16.0, 10);
+            currentTemperature = await AdjustTemperature(client, sensors, currentTemperature, 16.0, 10);
 
             // Phase 3: Hold at 16°C for 10 seconds
-            currentTemperature = await HoldTemperature(client, currentTemperature, 16.0, 10);
+            currentTemperature = await HoldTemperature(client, sensors, currentTemperature, 16.0, 10);
 
             // Phase 4: Gradually adjust to the user-defined target temperature and maintain
-            currentTemperature = await AdjustTemperature(client, currentTemperature, finalTargetTemperature, 20);
-            currentTemperature = await HoldTemperature(client, currentTemperature, finalTargetTemperature, int.MaxValue); // Maintain until exit
+            currentTemperature = await AdjustTemperature(client, sensors, currentTemperature, finalTargetTemperature, 20);
+            currentTemperature = await HoldTemperature(client, sensors, currentTemperature, finalTargetTemperature, int.MaxValue); // Maintain until exit
         }
     }
 
-    static async Task<double> AdjustTemperature(HttpClient client, double currentTemperature, double targetTemperature, int durationSeconds)
+    static async Task<double> AdjustTemperature(HttpClient client, IEnumerable<ISensor> sensors, double currentTemperature, double targetTemperature, int durationSeconds)
     {
         Console.WriteLine($"Adjusting temperature to {targetTemperature}°C over {durationSeconds} seconds...");
         int intervalMs = 1000; // 1-second intervals
@@ -447,14 +470,14 @@ class Program
 
             // Wait for a second and fetch the updated temperature
             await Task.Delay(intervalMs);
-            currentTemperature = await GetAverageTemperature(client);
+            currentTemperature = await GetAverageTemperature(sensors);
             Console.WriteLine($"Current Temperature: {currentTemperature:F1}°C");
         }
 
         return currentTemperature;
     }
 
-    static async Task<double> HoldTemperature(HttpClient client, double currentTemperature, double targetTemperature, int durationSeconds)
+    static async Task<double> HoldTemperature(HttpClient client, IEnumerable<ISensor> sensors, double currentTemperature, double targetTemperature, int durationSeconds)
     {
         Console.WriteLine($"Holding temperature at {targetTemperature}°C for {durationSeconds} seconds...");
         int intervalMs = 1000; // 1-second intervals
@@ -476,22 +499,30 @@ class Program
 
             // Wait for a second and fetch the updated temperature
             await Task.Delay(intervalMs);
-            currentTemperature = await GetAverageTemperature(client);
+            currentTemperature = await GetAverageTemperature(sensors);
             Console.WriteLine($"Current Temperature: {currentTemperature:F1}°C");
         }
 
         return currentTemperature;
     }
 
-    static async Task<double> GetAverageTemperature(HttpClient client)
+    /// <summary>
+    /// Calculates the average temperature across all provided sensor adapters.
+    /// </summary>
+    /// <param name="sensors">The collection of <see cref="ISensor"/> adapters to query.</param>
+    /// <returns>The mean temperature as a <see cref="double"/>.</returns>
+    static async Task<double> GetAverageTemperature(IEnumerable<ISensor> sensors)
     {
-        // Fetch sensor temperatures and calculate the average
-        var sensor1 = double.Parse(await GetSensor1Temperature(client));
-        var sensor2 = await GetSensor2Temperature(client);
-        var sensor3 = (double)await GetSensor3Temperature(client);
+        double total = 0;
+        int count = 0;
 
-        double avgTemperature = (sensor1 + sensor2 + sensor3) / 3;
-        return avgTemperature;
+        foreach (var sensor in sensors)
+        {
+            total += await sensor.GetTemperatureAsync();
+            count++;
+        }
+
+        return count > 0 ? total / count : 0;
     }
 
     static async Task SetAllHeaters(HttpClient client, int level)
@@ -511,62 +542,6 @@ class Program
     }
 
  
-
-    static async Task<string> GetSensor1Temperature(HttpClient client)
-    {
-        var response = await client.GetAsync("api/Sensor/sensor1");
-        if (response.IsSuccessStatusCode)
-        {
-            return await response.Content.ReadAsStringAsync();
-        }
-        throw new Exception($"Failed to get temperature from Sensor 1: {response.ReasonPhrase}");
-    }
-
-    static async Task<int> GetSensor2Temperature(HttpClient client)
-    {
-        var response = await client.GetAsync("api/Sensor/sensor2");
-        if (response.IsSuccessStatusCode)
-        {
-            var content = await response.Content.ReadAsStringAsync();
-            if (int.TryParse(content, out int temp))
-            {
-                return temp;
-            }
-            throw new Exception("Failed to parse Sensor 2 temperature as an integer.");
-        }
-        throw new Exception($"Failed to get temperature from Sensor 2: {response.ReasonPhrase}");
-    }
-
-    static async Task<decimal> GetSensor3Temperature(HttpClient client)
-    {
-        var response = await client.GetAsync("api/Sensor/sensor3");
-        if (response.IsSuccessStatusCode)
-        {
-            var content = await response.Content.ReadAsStringAsync();
-            if (decimal.TryParse(content, out decimal temp))
-            {
-                return temp;
-            }
-            throw new Exception("Failed to parse Sensor 3 temperature as a decimal.");
-        }
-        throw new Exception($"Failed to get temperature from Sensor 3: {response.ReasonPhrase}");
-    }
-
-   
-
-   
-
-    static async Task<double> GetSensorTemperature(HttpClient client, int sensorId)
-    {
-        var response = await client.GetAsync($"api/sensor/{sensorId}");
-        if (response.IsSuccessStatusCode)
-        {
-            var tempString = await response.Content.ReadAsStringAsync();
-            return double.Parse(tempString);
-        }
-
-        throw new Exception($"Failed to get temperature from sensor {sensorId}: {response.ReasonPhrase}");
-    }
 
     static async Task SetHeaterLevel(HttpClient client, int heaterId, int level)
     {

--- a/UglyClient.Tests/Adapters/Sensor1AdapterTests.cs
+++ b/UglyClient.Tests/Adapters/Sensor1AdapterTests.cs
@@ -1,0 +1,125 @@
+using System.Net;
+using Moq;
+using Moq.Protected;
+using UglyClient.Adapters;
+using Xunit;
+
+namespace UglyClient.Tests.Adapters;
+
+/// <summary>
+/// Unit tests for <see cref="Sensor1Adapter"/>.
+/// Verifies that the adapter correctly converts the raw <see cref="string"/> HTTP response
+/// to a <see cref="double"/> and that HTTP failure paths throw the expected exceptions.
+/// </summary>
+public class Sensor1AdapterTests
+{
+    /// <summary>
+    /// Creates an <see cref="HttpClient"/> whose <see cref="HttpMessageHandler"/> is backed by
+    /// the supplied mock, allowing HTTP responses to be controlled in tests.
+    /// </summary>
+    /// <param name="handlerMock">The mocked <see cref="HttpMessageHandler"/>.</param>
+    /// <returns>An <see cref="HttpClient"/> wired to the mock handler.</returns>
+    private static HttpClient BuildClient(Mock<HttpMessageHandler> handlerMock)
+    {
+        return new HttpClient(handlerMock.Object)
+        {
+            BaseAddress = new Uri("http://test-server/")
+        };
+    }
+
+    /// <summary>
+    /// Creates a mock handler that returns the given body with the given status code.
+    /// </summary>
+    private static Mock<HttpMessageHandler> CreateHandler(HttpStatusCode statusCode, string responseBody)
+    {
+        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(responseBody)
+            });
+        return mock;
+    }
+
+    /// <summary>
+    /// When the API returns a valid numeric string, <see cref="Sensor1Adapter.GetTemperatureAsync"/>
+    /// should parse it and return the expected <see cref="double"/>.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_ValidStringResponse_ReturnsDouble()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "21.5");
+        var adapter = new Sensor1Adapter(BuildClient(handler));
+
+        // Act
+        var result = await adapter.GetTemperatureAsync();
+
+        // Assert
+        Assert.Equal(21.5, result, precision: 5);
+    }
+
+    /// <summary>
+    /// When the API returns an integer string, the adapter should still parse it correctly.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_IntegerStringResponse_ReturnsDouble()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "19");
+        var adapter = new Sensor1Adapter(BuildClient(handler));
+
+        // Act
+        var result = await adapter.GetTemperatureAsync();
+
+        // Assert
+        Assert.Equal(19.0, result, precision: 5);
+    }
+
+    /// <summary>
+    /// When the HTTP response is not a success status code, an <see cref="Exception"/> should
+    /// be thrown describing the failure.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_HttpFailure_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.ServiceUnavailable, string.Empty);
+        var adapter = new Sensor1Adapter(BuildClient(handler));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
+        Assert.Contains("Sensor 1", ex.Message);
+    }
+
+    /// <summary>
+    /// When the HTTP response body is not a parseable number, an <see cref="Exception"/>
+    /// should be thrown with an appropriate message.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_UnparsableBody_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "not-a-number");
+        var adapter = new Sensor1Adapter(BuildClient(handler));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
+        Assert.Contains("Sensor 1", ex.Message);
+    }
+
+    /// <summary>
+    /// Passing a null <see cref="HttpClient"/> to the constructor should throw
+    /// <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [Fact]
+    public void Constructor_NullClient_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new Sensor1Adapter(null!));
+    }
+}

--- a/UglyClient.Tests/Adapters/Sensor2AdapterTests.cs
+++ b/UglyClient.Tests/Adapters/Sensor2AdapterTests.cs
@@ -1,0 +1,139 @@
+using System.Net;
+using Moq;
+using Moq.Protected;
+using UglyClient.Adapters;
+using Xunit;
+
+namespace UglyClient.Tests.Adapters;
+
+/// <summary>
+/// Unit tests for <see cref="Sensor2Adapter"/>.
+/// Verifies that the adapter correctly converts the raw <see cref="int"/> HTTP response
+/// to a <see cref="double"/> and that HTTP failure paths throw the expected exceptions.
+/// </summary>
+public class Sensor2AdapterTests
+{
+    /// <summary>
+    /// Creates an <see cref="HttpClient"/> whose <see cref="HttpMessageHandler"/> is backed by
+    /// the supplied mock, allowing HTTP responses to be controlled in tests.
+    /// </summary>
+    private static HttpClient BuildClient(Mock<HttpMessageHandler> handlerMock)
+    {
+        return new HttpClient(handlerMock.Object)
+        {
+            BaseAddress = new Uri("http://test-server/")
+        };
+    }
+
+    /// <summary>
+    /// Creates a mock handler that returns the given body with the given status code.
+    /// </summary>
+    private static Mock<HttpMessageHandler> CreateHandler(HttpStatusCode statusCode, string responseBody)
+    {
+        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(responseBody)
+            });
+        return mock;
+    }
+
+    /// <summary>
+    /// When the API returns a valid integer string, <see cref="Sensor2Adapter.GetTemperatureAsync"/>
+    /// should parse it and return the expected <see cref="double"/>.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_ValidIntegerResponse_ReturnsDouble()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "22");
+        var adapter = new Sensor2Adapter(BuildClient(handler));
+
+        // Act
+        var result = await adapter.GetTemperatureAsync();
+
+        // Assert
+        Assert.Equal(22.0, result, precision: 5);
+    }
+
+    /// <summary>
+    /// Verifies that a negative integer temperature is correctly widened to a negative double.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_NegativeInteger_ReturnsNegativeDouble()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "-5");
+        var adapter = new Sensor2Adapter(BuildClient(handler));
+
+        // Act
+        var result = await adapter.GetTemperatureAsync();
+
+        // Assert
+        Assert.Equal(-5.0, result, precision: 5);
+    }
+
+    /// <summary>
+    /// When the HTTP response is not a success status code, an <see cref="Exception"/> should
+    /// be thrown describing the failure.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_HttpFailure_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.InternalServerError, string.Empty);
+        var adapter = new Sensor2Adapter(BuildClient(handler));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
+        Assert.Contains("Sensor 2", ex.Message);
+    }
+
+    /// <summary>
+    /// When the HTTP response body is a decimal (not a valid integer), an <see cref="Exception"/>
+    /// should be thrown.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_DecimalBody_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "21.7");
+        var adapter = new Sensor2Adapter(BuildClient(handler));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
+        Assert.Contains("Sensor 2", ex.Message);
+    }
+
+    /// <summary>
+    /// When the HTTP response body is not a parseable integer, an <see cref="Exception"/>
+    /// should be thrown.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_UnparsableBody_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "not-a-number");
+        var adapter = new Sensor2Adapter(BuildClient(handler));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
+        Assert.Contains("Sensor 2", ex.Message);
+    }
+
+    /// <summary>
+    /// Passing a null <see cref="HttpClient"/> to the constructor should throw
+    /// <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [Fact]
+    public void Constructor_NullClient_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new Sensor2Adapter(null!));
+    }
+}

--- a/UglyClient.Tests/Adapters/Sensor3AdapterTests.cs
+++ b/UglyClient.Tests/Adapters/Sensor3AdapterTests.cs
@@ -1,0 +1,140 @@
+using System.Net;
+using Moq;
+using Moq.Protected;
+using UglyClient.Adapters;
+using Xunit;
+
+namespace UglyClient.Tests.Adapters;
+
+/// <summary>
+/// Unit tests for <see cref="Sensor3Adapter"/>.
+/// Verifies that the adapter correctly converts the raw <see cref="decimal"/> HTTP response
+/// to a <see cref="double"/> and that HTTP failure paths throw the expected exceptions.
+/// </summary>
+public class Sensor3AdapterTests
+{
+    /// <summary>
+    /// Creates an <see cref="HttpClient"/> whose <see cref="HttpMessageHandler"/> is backed by
+    /// the supplied mock, allowing HTTP responses to be controlled in tests.
+    /// </summary>
+    private static HttpClient BuildClient(Mock<HttpMessageHandler> handlerMock)
+    {
+        return new HttpClient(handlerMock.Object)
+        {
+            BaseAddress = new Uri("http://test-server/")
+        };
+    }
+
+    /// <summary>
+    /// Creates a mock handler that returns the given body with the given status code.
+    /// </summary>
+    private static Mock<HttpMessageHandler> CreateHandler(HttpStatusCode statusCode, string responseBody)
+    {
+        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(responseBody)
+            });
+        return mock;
+    }
+
+    /// <summary>
+    /// When the API returns a valid decimal string, <see cref="Sensor3Adapter.GetTemperatureAsync"/>
+    /// should parse it and return the expected <see cref="double"/>.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_ValidDecimalResponse_ReturnsDouble()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "23.75");
+        var adapter = new Sensor3Adapter(BuildClient(handler));
+
+        // Act
+        var result = await adapter.GetTemperatureAsync();
+
+        // Assert
+        Assert.Equal(23.75, result, precision: 5);
+    }
+
+    /// <summary>
+    /// When the API returns a whole-number decimal string, it should be correctly converted.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_WholeNumberDecimalResponse_ReturnsDouble()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "18.0");
+        var adapter = new Sensor3Adapter(BuildClient(handler));
+
+        // Act
+        var result = await adapter.GetTemperatureAsync();
+
+        // Assert
+        Assert.Equal(18.0, result, precision: 5);
+    }
+
+    /// <summary>
+    /// Verifies that negative decimal temperatures are correctly handled.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_NegativeDecimal_ReturnsNegativeDouble()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "-3.5");
+        var adapter = new Sensor3Adapter(BuildClient(handler));
+
+        // Act
+        var result = await adapter.GetTemperatureAsync();
+
+        // Assert
+        Assert.Equal(-3.5, result, precision: 5);
+    }
+
+    /// <summary>
+    /// When the HTTP response is not a success status code, an <see cref="Exception"/> should
+    /// be thrown describing the failure.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_HttpFailure_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.NotFound, string.Empty);
+        var adapter = new Sensor3Adapter(BuildClient(handler));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
+        Assert.Contains("Sensor 3", ex.Message);
+    }
+
+    /// <summary>
+    /// When the HTTP response body is not a parseable decimal, an <see cref="Exception"/>
+    /// should be thrown.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_UnparsableBody_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "not-a-number");
+        var adapter = new Sensor3Adapter(BuildClient(handler));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
+        Assert.Contains("Sensor 3", ex.Message);
+    }
+
+    /// <summary>
+    /// Passing a null <see cref="HttpClient"/> to the constructor should throw
+    /// <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [Fact]
+    public void Constructor_NullClient_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new Sensor3Adapter(null!));
+    }
+}

--- a/UglyClient.Tests/UglyClient.Tests.csproj
+++ b/UglyClient.Tests/UglyClient.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\UglyClient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/UglyClient.csproj
+++ b/UglyClient.csproj
@@ -7,4 +7,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- Exclude the test project subdirectory from the main project's compilation glob -->
+    <Compile Remove="UglyClient.Tests/**" />
+  </ItemGroup>
+
 </Project>

--- a/UglyClient.sln
+++ b/UglyClient.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.11.35312.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UglyClient", "UglyClient.csproj", "{ADC10BBC-0313-4A37-A091-3505B3D19BC1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UglyClient.Tests", "UglyClient.Tests\UglyClient.Tests.csproj", "{138E2734-C666-4DE6-9D56-E192D529B058}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{ADC10BBC-0313-4A37-A091-3505B3D19BC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ADC10BBC-0313-4A37-A091-3505B3D19BC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ADC10BBC-0313-4A37-A091-3505B3D19BC1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{138E2734-C666-4DE6-9D56-E192D529B058}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{138E2734-C666-4DE6-9D56-E192D529B058}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{138E2734-C666-4DE6-9D56-E192D529B058}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{138E2734-C666-4DE6-9D56-E192D529B058}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

Closes #2

Implements the **Adapter Pattern** (primary ICA assessed pattern) to unify the three incompatible sensor temperature methods into a single `ISensor` interface.

## Changes

### New files
| File | Description |
|---|---|
| `Interfaces/ISensor.cs` | Interface contract: `Task<double> GetTemperatureAsync()` |
| `Adapters/Sensor1Adapter.cs` | Wraps `api/Sensor/sensor1`, parses `string` → `double` |
| `Adapters/Sensor2Adapter.cs` | Wraps `api/Sensor/sensor2`, converts `int` → `double` |
| `Adapters/Sensor3Adapter.cs` | Wraps `api/Sensor/sensor3`, casts `decimal` → `double` |
| `UglyClient.Tests/UglyClient.Tests.csproj` | xUnit test project (net9.0, Moq) |
| `UglyClient.Tests/Adapters/Sensor1AdapterTests.cs` | 5 tests: string→double, failure paths |
| `UglyClient.Tests/Adapters/Sensor2AdapterTests.cs` | 6 tests: int→double, failure paths |
| `UglyClient.Tests/Adapters/Sensor3AdapterTests.cs` | 6 tests: decimal→double, failure paths |

### Modified files
- **`Program.cs`**
  - Instantiates `Sensor1Adapter`, `Sensor2Adapter`, `Sensor3Adapter` after `HttpClient` setup
  - `case "3"`: switch on `sensorId` to pick the right adapter, call `GetTemperatureAsync()`
  - `case "4"`: replaced `GetSensor1/2/3Temperature(client)` with adapter calls
  - `case "6"`: replaced `GetSensor1/2/3Temperature(client)` with adapter calls
  - `Reset()`: iterates `IEnumerable<ISensor>` instead of calling named methods
  - `GetAverageTemperature()`: now takes `IEnumerable<ISensor>`, iterates via the interface
  - `AdjustTemperature()` / `HoldTemperature()` / `RunTemperatureControlLoop()`: updated signatures to accept `IEnumerable<ISensor>`
  - **Removed**: `GetSensor1Temperature()`, `GetSensor2Temperature()`, `GetSensor3Temperature()`, `GetSensorTemperature()` static methods
- **`UglyClient.csproj`**: excludes `UglyClient.Tests/**` from main project compilation glob

## Test results
```
Test summary: total: 17, failed: 0, succeeded: 17, skipped: 0
```

## Acceptance criteria
- [x] `ISensor` interface in `Interfaces/ISensor.cs`
- [x] Three adapter classes in `Adapters/`
- [x] All three return `double`
- [x] Old `GetSensor1/2/3Temperature()` static methods removed from `Program.cs`
- [x] Unit tests for each adapter (type conversion + API failure paths)
