### PR TITLE
feat: implement IHeaterService and HeaterService (#4)

### DIFF
--- a/Adapters/Sensor1Adapter.cs
+++ b/Adapters/Sensor1Adapter.cs
@@ -1,0 +1,57 @@
+using UglyClient.Interfaces;
+
+namespace UglyClient.Adapters;
+
+/// <summary>
+/// Adapter that wraps the Sensor 1 HTTP endpoint and converts its raw <see cref="string"/>
+/// response into a <see cref="double"/> temperature value, conforming to <see cref="ISensor"/>.
+/// </summary>
+/// <remarks>
+/// Sensor 1 returns its reading as a plain text string (e.g. <c>"21.5"</c>).
+/// This adapter parses that string with <see cref="double.Parse(string)"/> so that
+/// callers never need to know the underlying representation.
+/// </remarks>
+public sealed class Sensor1Adapter : ISensor
+{
+    /// <summary>The shared <see cref="HttpClient"/> used to make requests to the sensor API.</summary>
+    private readonly HttpClient _client;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="Sensor1Adapter"/>.
+    /// </summary>
+    /// <param name="client">
+    /// The <see cref="HttpClient"/> pre-configured with the base address and any
+    /// required authentication headers.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="client"/> is <see langword="null"/>.
+    /// </exception>
+    public Sensor1Adapter(HttpClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Calls <c>GET api/Sensor/sensor1</c>. The API returns the temperature as a
+    /// plain <see cref="string"/> which is parsed to <see cref="double"/>.
+    /// </remarks>
+    public async Task<double> GetTemperatureAsync()
+    {
+        var response = await _client.GetAsync("api/Sensor/sensor1");
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception($"Failed to get temperature from Sensor 1: {response.ReasonPhrase}");
+        }
+
+        var content = await response.Content.ReadAsStringAsync();
+
+        if (!double.TryParse(content, out double temperature))
+        {
+            throw new Exception($"Failed to parse Sensor 1 temperature as a double. Raw value: '{content}'");
+        }
+
+        return temperature;
+    }
+}

--- a/Adapters/Sensor2Adapter.cs
+++ b/Adapters/Sensor2Adapter.cs
@@ -1,0 +1,59 @@
+using UglyClient.Interfaces;
+
+namespace UglyClient.Adapters;
+
+/// <summary>
+/// Adapter that wraps the Sensor 2 HTTP endpoint and converts its raw <see cref="int"/>
+/// response into a <see cref="double"/> temperature value, conforming to <see cref="ISensor"/>.
+/// </summary>
+/// <remarks>
+/// Sensor 2 returns its reading as a plain integer string (e.g. <c>"21"</c>).
+/// This adapter parses that integer with <see cref="int.TryParse(string, out int)"/> and
+/// widens it to <see cref="double"/> so that callers never need to know the underlying
+/// representation.
+/// </remarks>
+public sealed class Sensor2Adapter : ISensor
+{
+    /// <summary>The shared <see cref="HttpClient"/> used to make requests to the sensor API.</summary>
+    private readonly HttpClient _client;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="Sensor2Adapter"/>.
+    /// </summary>
+    /// <param name="client">
+    /// The <see cref="HttpClient"/> pre-configured with the base address and any
+    /// required authentication headers.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="client"/> is <see langword="null"/>.
+    /// </exception>
+    public Sensor2Adapter(HttpClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Calls <c>GET api/Sensor/sensor2</c>. The API returns the temperature as an
+    /// integer string which is parsed to <see cref="int"/> and then widened to
+    /// <see cref="double"/>.
+    /// </remarks>
+    public async Task<double> GetTemperatureAsync()
+    {
+        var response = await _client.GetAsync("api/Sensor/sensor2");
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception($"Failed to get temperature from Sensor 2: {response.ReasonPhrase}");
+        }
+
+        var content = await response.Content.ReadAsStringAsync();
+
+        if (!int.TryParse(content, out int temperature))
+        {
+            throw new Exception($"Failed to parse Sensor 2 temperature as an integer. Raw value: '{content}'");
+        }
+
+        return (double)temperature;
+    }
+}

--- a/Adapters/Sensor3Adapter.cs
+++ b/Adapters/Sensor3Adapter.cs
@@ -1,0 +1,59 @@
+using UglyClient.Interfaces;
+
+namespace UglyClient.Adapters;
+
+/// <summary>
+/// Adapter that wraps the Sensor 3 HTTP endpoint and converts its raw <see cref="decimal"/>
+/// response into a <see cref="double"/> temperature value, conforming to <see cref="ISensor"/>.
+/// </summary>
+/// <remarks>
+/// Sensor 3 returns its reading as a decimal string (e.g. <c>"21.75"</c>).
+/// This adapter parses that decimal with <see cref="decimal.TryParse(string, out decimal)"/>
+/// and casts it to <see cref="double"/> so that callers never need to know the underlying
+/// representation.
+/// </remarks>
+public sealed class Sensor3Adapter : ISensor
+{
+    /// <summary>The shared <see cref="HttpClient"/> used to make requests to the sensor API.</summary>
+    private readonly HttpClient _client;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="Sensor3Adapter"/>.
+    /// </summary>
+    /// <param name="client">
+    /// The <see cref="HttpClient"/> pre-configured with the base address and any
+    /// required authentication headers.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="client"/> is <see langword="null"/>.
+    /// </exception>
+    public Sensor3Adapter(HttpClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Calls <c>GET api/Sensor/sensor3</c>. The API returns the temperature as a
+    /// decimal string which is parsed to <see cref="decimal"/> and then cast to
+    /// <see cref="double"/>.
+    /// </remarks>
+    public async Task<double> GetTemperatureAsync()
+    {
+        var response = await _client.GetAsync("api/Sensor/sensor3");
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception($"Failed to get temperature from Sensor 3: {response.ReasonPhrase}");
+        }
+
+        var content = await response.Content.ReadAsStringAsync();
+
+        if (!decimal.TryParse(content, out decimal temperature))
+        {
+            throw new Exception($"Failed to parse Sensor 3 temperature as a decimal. Raw value: '{content}'");
+        }
+
+        return (double)temperature;
+    }
+}

--- a/Interfaces/ISensor.cs
+++ b/Interfaces/ISensor.cs
@@ -1,0 +1,23 @@
+namespace UglyClient.Interfaces;
+
+/// <summary>
+/// Defines the contract for a temperature sensor.
+/// Implementing this interface as part of the Adapter Pattern ensures that all
+/// sensor adapters — regardless of their underlying HTTP response format — expose
+/// a unified <see cref="GetTemperatureAsync"/> method that returns a <see cref="double"/>.
+/// </summary>
+public interface ISensor
+{
+    /// <summary>
+    /// Asynchronously retrieves the current temperature reading from the sensor.
+    /// </summary>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that resolves to the sensor temperature as a
+    /// <see cref="double"/> (degrees Celsius).
+    /// </returns>
+    /// <exception cref="Exception">
+    /// Thrown when the HTTP request fails or the response cannot be parsed into a
+    /// valid temperature value.
+    /// </exception>
+    Task<double> GetTemperatureAsync();
+}

--- a/Program.cs
+++ b/Program.cs
@@ -2,7 +2,9 @@
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
+using UglyClient.Adapters;
 using UglyClient.Config;
+using UglyClient.Interfaces;
 using UglyClient.Models;
 
 class Program
@@ -24,6 +26,13 @@ class Program
         // Must match the API key in ApiKeyManager (dictionary key)
         // MUST match a DICTIONARY KEY on the server:
         client.DefaultRequestHeaders.Add("X-Api-Key", config.ApiKey);
+
+        // Adapter Pattern: each sensor adapter wraps its own HTTP call and converts
+        // the raw response type to double, conforming to ISensor.
+        ISensor sensor1Adapter = new Sensor1Adapter(client);
+        ISensor sensor2Adapter = new Sensor2Adapter(client);
+        ISensor sensor3Adapter = new Sensor3Adapter(client);
+        ISensor[] sensorAdapters = [sensor1Adapter, sensor2Adapter, sensor3Adapter];
 
         while (true)
         {
@@ -98,8 +107,23 @@ class Program
                     {
                         try
                         {
-                            double temperature = await GetSensorTemperature(client, sensorId);
-                            Console.WriteLine($"Sensor {sensorId} Temperature: {temperature:F1}°C");
+                            ISensor? selectedAdapter = sensorId switch
+                            {
+                                1 => sensor1Adapter,
+                                2 => sensor2Adapter,
+                                3 => sensor3Adapter,
+                                _ => null
+                            };
+
+                            if (selectedAdapter is null)
+                            {
+                                Console.WriteLine($"Sensor {sensorId} not found. Valid sensors are 1, 2, or 3.");
+                            }
+                            else
+                            {
+                                double temperature = await selectedAdapter.GetTemperatureAsync();
+                                Console.WriteLine($"Sensor {sensorId} Temperature: {temperature:F1}°C");
+                            }
                         }
                         catch (Exception ex)
                         {
@@ -158,14 +182,14 @@ class Program
                         Console.WriteLine("Fetching sensor temperatures individually...");
                         try
                         {
-                            var sensor1Temp = await GetSensor1Temperature(client);
-                            Console.WriteLine($"  Sensor 1: Temperature {sensor1Temp} (Deg)");
+                            var s1Temp = await sensor1Adapter.GetTemperatureAsync();
+                            Console.WriteLine($"  Sensor 1: Temperature {s1Temp:F1} (Deg)");
 
-                            var sensor2Temp = await GetSensor2Temperature(client);
-                            Console.WriteLine($"  Sensor 2: Temperature {sensor2Temp} (Deg)");
+                            var s2Temp = await sensor2Adapter.GetTemperatureAsync();
+                            Console.WriteLine($"  Sensor 2: Temperature {s2Temp:F1} (Deg)");
 
-                            var sensor3Temp = await GetSensor3Temperature(client);
-                            Console.WriteLine($"  Sensor 3: Temperature {sensor3Temp} (Deg)");
+                            var s3Temp = await sensor3Adapter.GetTemperatureAsync();
+                            Console.WriteLine($"  Sensor 3: Temperature {s3Temp:F1} (Deg)");
                         }
                         catch (Exception ex)
                         {
@@ -181,21 +205,21 @@ class Program
                     //await RunTemperatureControlLoop(client);
                     Console.WriteLine("Starting temperature control algorithm...");
                     Console.Write("Provide a final Temp Value: ");
-                    double currentTemperature = await GetAverageTemperature(client);
+                    double currentTemperature = await GetAverageTemperature(sensorAdapters);
                     while (true)
                     {
                         // Phase 1: Gradually increase to 20°C over 30 seconds
-                        currentTemperature = await AdjustTemperature(client, currentTemperature, 20.0, 30);
+                        currentTemperature = await AdjustTemperature(client, sensorAdapters, currentTemperature, 20.0, 30);
 
                         // Phase 2: Rapidly cool to 16°C
-                        currentTemperature = await AdjustTemperature(client, currentTemperature, 16.0, 10);
+                        currentTemperature = await AdjustTemperature(client, sensorAdapters, currentTemperature, 16.0, 10);
 
                         // Phase 3: Hold at 16°C for 10 seconds
-                        currentTemperature = await HoldTemperature(client, currentTemperature, 16.0, 10);
+                        currentTemperature = await HoldTemperature(client, sensorAdapters, currentTemperature, 16.0, 10);
 
                         // Phase 4: Gradually return to 18°C and maintain
-                        currentTemperature = await AdjustTemperature(client, currentTemperature, 18.0, 20);
-                        currentTemperature = await HoldTemperature(client, currentTemperature, 18.0, int.MaxValue); // Maintain until exit
+                        currentTemperature = await AdjustTemperature(client, sensorAdapters, currentTemperature, 18.0, 20);
+                        currentTemperature = await HoldTemperature(client, sensorAdapters, currentTemperature, 18.0, int.MaxValue); // Maintain until exit
                     }
                 case "6":
                     // await Reset(client);
@@ -260,14 +284,14 @@ class Program
                                 Console.WriteLine("Fetching sensor temperatures individually...");
                                 try
                                 {
-                                    var sensor1Temp = await GetSensor1Temperature(client);
-                                    Console.WriteLine($"  Sensor 1: Temperature {sensor1Temp} (Deg)");
+                                    var s1Temp = await sensor1Adapter.GetTemperatureAsync();
+                                    Console.WriteLine($"  Sensor 1: Temperature {s1Temp:F1} (Deg)");
 
-                                    var sensor2Temp = await GetSensor2Temperature(client);
-                                    Console.WriteLine($"  Sensor 2: Temperature {sensor2Temp} (Deg)");
+                                    var s2Temp = await sensor2Adapter.GetTemperatureAsync();
+                                    Console.WriteLine($"  Sensor 2: Temperature {s2Temp:F1} (Deg)");
 
-                                    var sensor3Temp = await GetSensor3Temperature(client);
-                                    Console.WriteLine($"  Sensor 3: Temperature {sensor3Temp} (Deg)");
+                                    var s3Temp = await sensor3Adapter.GetTemperatureAsync();
+                                    Console.WriteLine($"  Sensor 3: Temperature {s3Temp:F1} (Deg)");
                                 }
                                 catch (Exception ex)
                                 {
@@ -298,7 +322,7 @@ class Program
         }
     }
 
-    private static async Task Reset(HttpClient client, SimulationConfig config)
+    private static async Task Reset(HttpClient client, SimulationConfig config, IEnumerable<ISensor> sensors)
     {
         Console.WriteLine("Resetting client state...");
 
@@ -361,14 +385,13 @@ class Program
                     Console.WriteLine("Fetching sensor temperatures individually...");
                     try
                     {
-                        var sensor1Temp = await GetSensor1Temperature(client);
-                        Console.WriteLine($"  Sensor 1: Temperature {sensor1Temp} (Deg)");
-
-                        var sensor2Temp = await GetSensor2Temperature(client);
-                        Console.WriteLine($"  Sensor 2: Temperature {sensor2Temp} (Deg)");
-
-                        var sensor3Temp = await GetSensor3Temperature(client);
-                        Console.WriteLine($"  Sensor 3: Temperature {sensor3Temp} (Deg)");
+                        int sensorIndex = 1;
+                        foreach (var sensor in sensors)
+                        {
+                            var temp = await sensor.GetTemperatureAsync();
+                            Console.WriteLine($"  Sensor {sensorIndex}: Temperature {temp:F1} (Deg)");
+                            sensorIndex++;
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -391,11 +414,11 @@ class Program
         }
     }
 
-    static async Task RunTemperatureControlLoop(HttpClient client)
+    static async Task RunTemperatureControlLoop(HttpClient client, IEnumerable<ISensor> sensors)
     {
         Console.WriteLine("Starting temperature control algorithm...");
 
-        double currentTemperature = await GetAverageTemperature(client);
+        double currentTemperature = await GetAverageTemperature(sensors);
 
         // Prompt user for the final target temperature in Phase 4
         Console.Write("Enter the final target temperature for Phase 4: ");
@@ -408,21 +431,21 @@ class Program
         while (true)
         {
             // Phase 1: Gradually increase to 20°C over 30 seconds
-            currentTemperature = await AdjustTemperature(client, currentTemperature, 20.0, 30);
+            currentTemperature = await AdjustTemperature(client, sensors, currentTemperature, 20.0, 30);
 
             // Phase 2: Rapidly cool to 16°C
-            currentTemperature = await AdjustTemperature(client, currentTemperature, 16.0, 10);
+            currentTemperature = await AdjustTemperature(client, sensors, currentTemperature, 16.0, 10);
 
             // Phase 3: Hold at 16°C for 10 seconds
-            currentTemperature = await HoldTemperature(client, currentTemperature, 16.0, 10);
+            currentTemperature = await HoldTemperature(client, sensors, currentTemperature, 16.0, 10);
 
             // Phase 4: Gradually adjust to the user-defined target temperature and maintain
-            currentTemperature = await AdjustTemperature(client, currentTemperature, finalTargetTemperature, 20);
-            currentTemperature = await HoldTemperature(client, currentTemperature, finalTargetTemperature, int.MaxValue); // Maintain until exit
+            currentTemperature = await AdjustTemperature(client, sensors, currentTemperature, finalTargetTemperature, 20);
+            currentTemperature = await HoldTemperature(client, sensors, currentTemperature, finalTargetTemperature, int.MaxValue); // Maintain until exit
         }
     }
 
-    static async Task<double> AdjustTemperature(HttpClient client, double currentTemperature, double targetTemperature, int durationSeconds)
+    static async Task<double> AdjustTemperature(HttpClient client, IEnumerable<ISensor> sensors, double currentTemperature, double targetTemperature, int durationSeconds)
     {
         Console.WriteLine($"Adjusting temperature to {targetTemperature}°C over {durationSeconds} seconds...");
         int intervalMs = 1000; // 1-second intervals
@@ -447,14 +470,14 @@ class Program
 
             // Wait for a second and fetch the updated temperature
             await Task.Delay(intervalMs);
-            currentTemperature = await GetAverageTemperature(client);
+            currentTemperature = await GetAverageTemperature(sensors);
             Console.WriteLine($"Current Temperature: {currentTemperature:F1}°C");
         }
 
         return currentTemperature;
     }
 
-    static async Task<double> HoldTemperature(HttpClient client, double currentTemperature, double targetTemperature, int durationSeconds)
+    static async Task<double> HoldTemperature(HttpClient client, IEnumerable<ISensor> sensors, double currentTemperature, double targetTemperature, int durationSeconds)
     {
         Console.WriteLine($"Holding temperature at {targetTemperature}°C for {durationSeconds} seconds...");
         int intervalMs = 1000; // 1-second intervals
@@ -476,22 +499,30 @@ class Program
 
             // Wait for a second and fetch the updated temperature
             await Task.Delay(intervalMs);
-            currentTemperature = await GetAverageTemperature(client);
+            currentTemperature = await GetAverageTemperature(sensors);
             Console.WriteLine($"Current Temperature: {currentTemperature:F1}°C");
         }
 
         return currentTemperature;
     }
 
-    static async Task<double> GetAverageTemperature(HttpClient client)
+    /// <summary>
+    /// Calculates the average temperature across all provided sensor adapters.
+    /// </summary>
+    /// <param name="sensors">The collection of <see cref="ISensor"/> adapters to query.</param>
+    /// <returns>The mean temperature as a <see cref="double"/>.</returns>
+    static async Task<double> GetAverageTemperature(IEnumerable<ISensor> sensors)
     {
-        // Fetch sensor temperatures and calculate the average
-        var sensor1 = double.Parse(await GetSensor1Temperature(client));
-        var sensor2 = await GetSensor2Temperature(client);
-        var sensor3 = (double)await GetSensor3Temperature(client);
+        double total = 0;
+        int count = 0;
 
-        double avgTemperature = (sensor1 + sensor2 + sensor3) / 3;
-        return avgTemperature;
+        foreach (var sensor in sensors)
+        {
+            total += await sensor.GetTemperatureAsync();
+            count++;
+        }
+
+        return count > 0 ? total / count : 0;
     }
 
     static async Task SetAllHeaters(HttpClient client, int level)
@@ -511,62 +542,6 @@ class Program
     }
 
  
-
-    static async Task<string> GetSensor1Temperature(HttpClient client)
-    {
-        var response = await client.GetAsync("api/Sensor/sensor1");
-        if (response.IsSuccessStatusCode)
-        {
-            return await response.Content.ReadAsStringAsync();
-        }
-        throw new Exception($"Failed to get temperature from Sensor 1: {response.ReasonPhrase}");
-    }
-
-    static async Task<int> GetSensor2Temperature(HttpClient client)
-    {
-        var response = await client.GetAsync("api/Sensor/sensor2");
-        if (response.IsSuccessStatusCode)
-        {
-            var content = await response.Content.ReadAsStringAsync();
-            if (int.TryParse(content, out int temp))
-            {
-                return temp;
-            }
-            throw new Exception("Failed to parse Sensor 2 temperature as an integer.");
-        }
-        throw new Exception($"Failed to get temperature from Sensor 2: {response.ReasonPhrase}");
-    }
-
-    static async Task<decimal> GetSensor3Temperature(HttpClient client)
-    {
-        var response = await client.GetAsync("api/Sensor/sensor3");
-        if (response.IsSuccessStatusCode)
-        {
-            var content = await response.Content.ReadAsStringAsync();
-            if (decimal.TryParse(content, out decimal temp))
-            {
-                return temp;
-            }
-            throw new Exception("Failed to parse Sensor 3 temperature as a decimal.");
-        }
-        throw new Exception($"Failed to get temperature from Sensor 3: {response.ReasonPhrase}");
-    }
-
-   
-
-   
-
-    static async Task<double> GetSensorTemperature(HttpClient client, int sensorId)
-    {
-        var response = await client.GetAsync($"api/sensor/{sensorId}");
-        if (response.IsSuccessStatusCode)
-        {
-            var tempString = await response.Content.ReadAsStringAsync();
-            return double.Parse(tempString);
-        }
-
-        throw new Exception($"Failed to get temperature from sensor {sensorId}: {response.ReasonPhrase}");
-    }
 
     static async Task SetHeaterLevel(HttpClient client, int heaterId, int level)
     {

--- a/Program.cs
+++ b/Program.cs
@@ -36,6 +36,9 @@ class Program
         // Facade / Service layer: FanService encapsulates all fan-related HTTP calls.
         IFanService fanService = new FanService(client, config.FanCount);
 
+        // Facade / Service layer: HeaterService encapsulates all heater-related HTTP calls.
+        IHeaterService heaterService = new HeaterService(client, config.HeaterCount);
+
         while (true)
         {
             Console.WriteLine("Simulation Control:");
@@ -84,7 +87,7 @@ class Program
                         {
                             try
                             {
-                                await SetHeaterLevel(client, heaterId, level);
+                                await heaterService.SetHeaterLevelAsync(heaterId, level);
                                 Console.WriteLine($"Heater {heaterId} level set to {level}.");
                             }
                             catch (Exception ex)
@@ -148,25 +151,10 @@ class Program
                             Console.WriteLine($"  Fan {fan.Id}: {(fan.IsOn ? "On" : "Off")}");
                         }
                         Console.WriteLine("Fetching heater levels individually...");
-                        for (int i = 1; i <= config.HeaterCount; i++)
+                        int heaterIndex4 = 1;
+                        foreach (var heaterLevel in await heaterService.GetAllHeaterLevelsAsync())
                         {
-                            var heaterResponse = await client.GetAsync($"api/heat/{i}/level");
-                            if (heaterResponse.IsSuccessStatusCode)
-                            {
-                                var levelString = await heaterResponse.Content.ReadAsStringAsync();
-                                if (int.TryParse(levelString, out int level))
-                                {
-                                    Console.WriteLine($"  Heater {i}: Level {level}");
-                                }
-                                else
-                                {
-                                    Console.WriteLine($"  Heater {i}: Failed to parse level.");
-                                }
-                            }
-                            else
-                            {
-                                Console.WriteLine($"  Heater {i}: Failed to fetch level.");
-                            }
+                            Console.WriteLine($"  Heater {heaterIndex4++}: Level {heaterLevel}");
                         }
                         Console.WriteLine("Fetching sensor temperatures individually...");
                         try
@@ -198,17 +186,17 @@ class Program
                     while (true)
                     {
                         // Phase 1: Gradually increase to 20°C over 30 seconds
-                        currentTemperature = await AdjustTemperature(client, fanService, sensorAdapters, currentTemperature, 20.0, 30);
+                        currentTemperature = await AdjustTemperature(heaterService, fanService, sensorAdapters, currentTemperature, 20.0, 30);
 
                         // Phase 2: Rapidly cool to 16°C
-                        currentTemperature = await AdjustTemperature(client, fanService, sensorAdapters, currentTemperature, 16.0, 10);
+                        currentTemperature = await AdjustTemperature(heaterService, fanService, sensorAdapters, currentTemperature, 16.0, 10);
 
                         // Phase 3: Hold at 16°C for 10 seconds
-                        currentTemperature = await HoldTemperature(client, fanService, sensorAdapters, currentTemperature, 16.0, 10);
+                        currentTemperature = await HoldTemperature(heaterService, fanService, sensorAdapters, currentTemperature, 16.0, 10);
 
                         // Phase 4: Gradually return to 18°C and maintain
-                        currentTemperature = await AdjustTemperature(client, fanService, sensorAdapters, currentTemperature, 18.0, 20);
-                        currentTemperature = await HoldTemperature(client, fanService, sensorAdapters, currentTemperature, 18.0, int.MaxValue); // Maintain until exit
+                        currentTemperature = await AdjustTemperature(heaterService, fanService, sensorAdapters, currentTemperature, 18.0, 20);
+                        currentTemperature = await HoldTemperature(heaterService, fanService, sensorAdapters, currentTemperature, 18.0, int.MaxValue); // Maintain until exit
                     }
                 case "6":
                     // await Reset(client);
@@ -235,25 +223,10 @@ class Program
 
                                 // Get individual heater levels
                                 Console.WriteLine("Fetching heater levels individually...");
-                                for (int i = 1; i <= config.HeaterCount; i++)
+                                int heaterIndex6 = 1;
+                                foreach (var heaterLevel in await heaterService.GetAllHeaterLevelsAsync())
                                 {
-                                    var heaterResponse = await client.GetAsync($"api/heat/{i}/level");
-                                    if (heaterResponse.IsSuccessStatusCode)
-                                    {
-                                        var levelString = await heaterResponse.Content.ReadAsStringAsync();
-                                        if (int.TryParse(levelString, out int level))
-                                        {
-                                            Console.WriteLine($"  Heater {i}: Level {level}");
-                                        }
-                                        else
-                                        {
-                                            Console.WriteLine($"  Heater {i}: Failed to parse level.");
-                                        }
-                                    }
-                                    else
-                                    {
-                                        Console.WriteLine($"  Heater {i}: Failed to fetch level.");
-                                    }
+                                    Console.WriteLine($"  Heater {heaterIndex6++}: Level {heaterLevel}");
                                 }
 
                                 // Get individual sensor temperatures
@@ -298,7 +271,7 @@ class Program
         }
     }
 
-    private static async Task Reset(HttpClient client, SimulationConfig config, IFanService fanService, IEnumerable<ISensor> sensors)
+    private static async Task Reset(HttpClient client, IHeaterService heaterService, IFanService fanService, IEnumerable<ISensor> sensors)
     {
         Console.WriteLine("Resetting client state...");
 
@@ -323,25 +296,10 @@ class Program
 
                     // Get individual heater levels
                     Console.WriteLine("Fetching heater levels individually...");
-                    for (int i = 1; i <= config.HeaterCount; i++)
+                    int heaterIndexReset = 1;
+                    foreach (var heaterLevel in await heaterService.GetAllHeaterLevelsAsync())
                     {
-                        var heaterResponse = await client.GetAsync($"api/heat/{i}/level");
-                        if (heaterResponse.IsSuccessStatusCode)
-                        {
-                            var levelString = await heaterResponse.Content.ReadAsStringAsync();
-                            if (int.TryParse(levelString, out int level))
-                            {
-                                Console.WriteLine($"  Heater {i}: Level {level}");
-                            }
-                            else
-                            {
-                                Console.WriteLine($"  Heater {i}: Failed to parse level.");
-                            }
-                        }
-                        else
-                        {
-                            Console.WriteLine($"  Heater {i}: Failed to fetch level.");
-                        }
+                        Console.WriteLine($"  Heater {heaterIndexReset++}: Level {heaterLevel}");
                     }
 
                     // Get individual sensor temperatures
@@ -377,7 +335,7 @@ class Program
         }
     }
 
-    static async Task RunTemperatureControlLoop(HttpClient client, IFanService fanService, IEnumerable<ISensor> sensors)
+    static async Task RunTemperatureControlLoop(IHeaterService heaterService, IFanService fanService, IEnumerable<ISensor> sensors)
     {
         Console.WriteLine("Starting temperature control algorithm...");
 
@@ -394,21 +352,21 @@ class Program
         while (true)
         {
             // Phase 1: Gradually increase to 20°C over 30 seconds
-            currentTemperature = await AdjustTemperature(client, fanService, sensors, currentTemperature, 20.0, 30);
+            currentTemperature = await AdjustTemperature(heaterService, fanService, sensors, currentTemperature, 20.0, 30);
 
             // Phase 2: Rapidly cool to 16°C
-            currentTemperature = await AdjustTemperature(client, fanService, sensors, currentTemperature, 16.0, 10);
+            currentTemperature = await AdjustTemperature(heaterService, fanService, sensors, currentTemperature, 16.0, 10);
 
             // Phase 3: Hold at 16°C for 10 seconds
-            currentTemperature = await HoldTemperature(client, fanService, sensors, currentTemperature, 16.0, 10);
+            currentTemperature = await HoldTemperature(heaterService, fanService, sensors, currentTemperature, 16.0, 10);
 
             // Phase 4: Gradually adjust to the user-defined target temperature and maintain
-            currentTemperature = await AdjustTemperature(client, fanService, sensors, currentTemperature, finalTargetTemperature, 20);
-            currentTemperature = await HoldTemperature(client, fanService, sensors, currentTemperature, finalTargetTemperature, int.MaxValue); // Maintain until exit
+            currentTemperature = await AdjustTemperature(heaterService, fanService, sensors, currentTemperature, finalTargetTemperature, 20);
+            currentTemperature = await HoldTemperature(heaterService, fanService, sensors, currentTemperature, finalTargetTemperature, int.MaxValue); // Maintain until exit
         }
     }
 
-    static async Task<double> AdjustTemperature(HttpClient client, IFanService fanService, IEnumerable<ISensor> sensors, double currentTemperature, double targetTemperature, int durationSeconds)
+    static async Task<double> AdjustTemperature(IHeaterService heaterService, IFanService fanService, IEnumerable<ISensor> sensors, double currentTemperature, double targetTemperature, int durationSeconds)
     {
         Console.WriteLine($"Adjusting temperature to {targetTemperature}°C over {durationSeconds} seconds...");
         int intervalMs = 1000; // 1-second intervals
@@ -421,13 +379,13 @@ class Program
             if (currentTemperature < targetTemperature)
             {
                 // Turn on heaters and reduce fan activity
-                await SetAllHeaters(client, 3); // Set heaters to level 3
+                await heaterService.SetAllHeatersAsync(3); // Set heaters to level 3
                 await fanService.SetAllFansAsync(false);    // Turn off fans
             }
             else
             {
                 // Turn off heaters and increase fan activity
-                await SetAllHeaters(client, 0); // Turn off heaters
+                await heaterService.SetAllHeatersAsync(0); // Turn off heaters
                 await fanService.SetAllFansAsync(true);     // Turn on fans
             }
 
@@ -440,7 +398,7 @@ class Program
         return currentTemperature;
     }
 
-    static async Task<double> HoldTemperature(HttpClient client, IFanService fanService, IEnumerable<ISensor> sensors, double currentTemperature, double targetTemperature, int durationSeconds)
+    static async Task<double> HoldTemperature(IHeaterService heaterService, IFanService fanService, IEnumerable<ISensor> sensors, double currentTemperature, double targetTemperature, int durationSeconds)
     {
         Console.WriteLine($"Holding temperature at {targetTemperature}°C for {durationSeconds} seconds...");
         int intervalMs = 1000; // 1-second intervals
@@ -450,13 +408,13 @@ class Program
             if (currentTemperature < targetTemperature)
             {
                 // Turn on heaters slightly and reduce fans
-                await SetAllHeaters(client, 1); // Minimal heating
+                await heaterService.SetAllHeatersAsync(1); // Minimal heating
                 await fanService.SetAllFansAsync(false); // Reduce cooling
             }
             else if (currentTemperature > targetTemperature)
             {
                 // Turn off heaters and increase fans
-                await SetAllHeaters(client, 0); // Turn off heating
+                await heaterService.SetAllHeatersAsync(0); // Turn off heating
                 await fanService.SetAllFansAsync(true); // Activate cooling
             }
 
@@ -486,26 +444,6 @@ class Program
         }
 
         return count > 0 ? total / count : 0;
-    }
-
-    static async Task SetAllHeaters(HttpClient client, int level)
-    {
-        for (int i = 1; i <= 3; i++) // Assuming 3 heaters
-        {
-            await SetHeaterLevel(client, i, level);
-        }
-    }
-
-
-
-    static async Task SetHeaterLevel(HttpClient client, int heaterId, int level)
-    {
-        var response = await client.PostAsync($"api/heat/{heaterId}",
-            new StringContent(level.ToString(), System.Text.Encoding.UTF8, "application/json"));
-        if (!response.IsSuccessStatusCode)
-        {
-            throw new Exception($"Failed to set heater level {heaterId}: {response.ReasonPhrase}");
-        }
     }
 
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,11 +1,10 @@
 ﻿using System;
 using System.Net.Http;
-using System.Text.Json;
 using System.Threading.Tasks;
 using UglyClient.Adapters;
 using UglyClient.Config;
 using UglyClient.Interfaces;
-using UglyClient.Models;
+using UglyClient.Services;
 
 class Program
 {
@@ -34,6 +33,9 @@ class Program
         ISensor sensor3Adapter = new Sensor3Adapter(client);
         ISensor[] sensorAdapters = [sensor1Adapter, sensor2Adapter, sensor3Adapter];
 
+        // Facade / Service layer: FanService encapsulates all fan-related HTTP calls.
+        IFanService fanService = new FanService(client, config.FanCount);
+
         while (true)
         {
             Console.WriteLine("Simulation Control:");
@@ -59,7 +61,7 @@ class Program
 
                         try
                         {
-                            await SetFanState(client, fanId, isOn);
+                            await fanService.SetFanStateAsync(fanId, isOn);
                             Console.WriteLine($"Fan {fanId} has been turned {(isOn ? "On" : "Off")}.");
                         }
                         catch (Exception ex)
@@ -141,22 +143,9 @@ class Program
                     try
                     {
                         Console.WriteLine("Fetching fan states individually...");
-                        for (int i = 1; i <= config.FanCount; i++)
+                        foreach (var fan in await fanService.GetAllFanStatesAsync())
                         {
-                            var fanResponse = await client.GetAsync($"api/fans/{i}/state");
-                            if (fanResponse.IsSuccessStatusCode)
-                            {
-                                var fanJson = await fanResponse.Content.ReadAsStringAsync();
-                                var fan = JsonSerializer.Deserialize<FanDTO>(fanJson, new JsonSerializerOptions
-                                {
-                                    PropertyNameCaseInsensitive = true
-                                });
-                                Console.WriteLine($"  Fan {fan.Id}: {(fan.IsOn ? "On" : "Off")}");
-                            }
-                            else
-                            {
-                                Console.WriteLine($"  Fan {i}: Failed to fetch state.");
-                            }
+                            Console.WriteLine($"  Fan {fan.Id}: {(fan.IsOn ? "On" : "Off")}");
                         }
                         Console.WriteLine("Fetching heater levels individually...");
                         for (int i = 1; i <= config.HeaterCount; i++)
@@ -209,17 +198,17 @@ class Program
                     while (true)
                     {
                         // Phase 1: Gradually increase to 20°C over 30 seconds
-                        currentTemperature = await AdjustTemperature(client, sensorAdapters, currentTemperature, 20.0, 30);
+                        currentTemperature = await AdjustTemperature(client, fanService, sensorAdapters, currentTemperature, 20.0, 30);
 
                         // Phase 2: Rapidly cool to 16°C
-                        currentTemperature = await AdjustTemperature(client, sensorAdapters, currentTemperature, 16.0, 10);
+                        currentTemperature = await AdjustTemperature(client, fanService, sensorAdapters, currentTemperature, 16.0, 10);
 
                         // Phase 3: Hold at 16°C for 10 seconds
-                        currentTemperature = await HoldTemperature(client, sensorAdapters, currentTemperature, 16.0, 10);
+                        currentTemperature = await HoldTemperature(client, fanService, sensorAdapters, currentTemperature, 16.0, 10);
 
                         // Phase 4: Gradually return to 18°C and maintain
-                        currentTemperature = await AdjustTemperature(client, sensorAdapters, currentTemperature, 18.0, 20);
-                        currentTemperature = await HoldTemperature(client, sensorAdapters, currentTemperature, 18.0, int.MaxValue); // Maintain until exit
+                        currentTemperature = await AdjustTemperature(client, fanService, sensorAdapters, currentTemperature, 18.0, 20);
+                        currentTemperature = await HoldTemperature(client, fanService, sensorAdapters, currentTemperature, 18.0, int.MaxValue); // Maintain until exit
                     }
                 case "6":
                     // await Reset(client);
@@ -239,22 +228,9 @@ class Program
                             {
                                 // Get individual fan states
                                 Console.WriteLine("Fetching fan states individually...");
-                                for (int i = 1; i <= config.FanCount; i++)
+                                foreach (var fan in await fanService.GetAllFanStatesAsync())
                                 {
-                                    var fanResponse = await client.GetAsync($"api/fans/{i}/state");
-                                    if (fanResponse.IsSuccessStatusCode)
-                                    {
-                                        var fanJson = await fanResponse.Content.ReadAsStringAsync();
-                                        var fan = JsonSerializer.Deserialize<FanDTO>(fanJson, new JsonSerializerOptions
-                                        {
-                                            PropertyNameCaseInsensitive = true
-                                        });
-                                        Console.WriteLine($"  Fan {fan.Id}: {(fan.IsOn ? "On" : "Off")}");
-                                    }
-                                    else
-                                    {
-                                        Console.WriteLine($"  Fan {i}: Failed to fetch state.");
-                                    }
+                                    Console.WriteLine($"  Fan {fan.Id}: {(fan.IsOn ? "On" : "Off")}");
                                 }
 
                                 // Get individual heater levels
@@ -322,7 +298,7 @@ class Program
         }
     }
 
-    private static async Task Reset(HttpClient client, SimulationConfig config, IEnumerable<ISensor> sensors)
+    private static async Task Reset(HttpClient client, SimulationConfig config, IFanService fanService, IEnumerable<ISensor> sensors)
     {
         Console.WriteLine("Resetting client state...");
 
@@ -340,22 +316,9 @@ class Program
                 {
                     // Get individual fan states
                     Console.WriteLine("Fetching fan states individually...");
-                    for (int i = 1; i <= config.FanCount; i++)
+                    foreach (var fan in await fanService.GetAllFanStatesAsync())
                     {
-                        var fanResponse = await client.GetAsync($"api/fans/{i}/state");
-                        if (fanResponse.IsSuccessStatusCode)
-                        {
-                            var fanJson = await fanResponse.Content.ReadAsStringAsync();
-                            var fan = JsonSerializer.Deserialize<FanDTO>(fanJson, new JsonSerializerOptions
-                            {
-                                PropertyNameCaseInsensitive = true
-                            });
-                            Console.WriteLine($"  Fan {fan.Id}: {(fan.IsOn ? "On" : "Off")}");
-                        }
-                        else
-                        {
-                            Console.WriteLine($"  Fan {i}: Failed to fetch state.");
-                        }
+                        Console.WriteLine($"  Fan {fan.Id}: {(fan.IsOn ? "On" : "Off")}");
                     }
 
                     // Get individual heater levels
@@ -414,7 +377,7 @@ class Program
         }
     }
 
-    static async Task RunTemperatureControlLoop(HttpClient client, IEnumerable<ISensor> sensors)
+    static async Task RunTemperatureControlLoop(HttpClient client, IFanService fanService, IEnumerable<ISensor> sensors)
     {
         Console.WriteLine("Starting temperature control algorithm...");
 
@@ -431,21 +394,21 @@ class Program
         while (true)
         {
             // Phase 1: Gradually increase to 20°C over 30 seconds
-            currentTemperature = await AdjustTemperature(client, sensors, currentTemperature, 20.0, 30);
+            currentTemperature = await AdjustTemperature(client, fanService, sensors, currentTemperature, 20.0, 30);
 
             // Phase 2: Rapidly cool to 16°C
-            currentTemperature = await AdjustTemperature(client, sensors, currentTemperature, 16.0, 10);
+            currentTemperature = await AdjustTemperature(client, fanService, sensors, currentTemperature, 16.0, 10);
 
             // Phase 3: Hold at 16°C for 10 seconds
-            currentTemperature = await HoldTemperature(client, sensors, currentTemperature, 16.0, 10);
+            currentTemperature = await HoldTemperature(client, fanService, sensors, currentTemperature, 16.0, 10);
 
             // Phase 4: Gradually adjust to the user-defined target temperature and maintain
-            currentTemperature = await AdjustTemperature(client, sensors, currentTemperature, finalTargetTemperature, 20);
-            currentTemperature = await HoldTemperature(client, sensors, currentTemperature, finalTargetTemperature, int.MaxValue); // Maintain until exit
+            currentTemperature = await AdjustTemperature(client, fanService, sensors, currentTemperature, finalTargetTemperature, 20);
+            currentTemperature = await HoldTemperature(client, fanService, sensors, currentTemperature, finalTargetTemperature, int.MaxValue); // Maintain until exit
         }
     }
 
-    static async Task<double> AdjustTemperature(HttpClient client, IEnumerable<ISensor> sensors, double currentTemperature, double targetTemperature, int durationSeconds)
+    static async Task<double> AdjustTemperature(HttpClient client, IFanService fanService, IEnumerable<ISensor> sensors, double currentTemperature, double targetTemperature, int durationSeconds)
     {
         Console.WriteLine($"Adjusting temperature to {targetTemperature}°C over {durationSeconds} seconds...");
         int intervalMs = 1000; // 1-second intervals
@@ -459,13 +422,13 @@ class Program
             {
                 // Turn on heaters and reduce fan activity
                 await SetAllHeaters(client, 3); // Set heaters to level 3
-                await SetAllFans(client, false); // Turn off fans
+                await fanService.SetAllFansAsync(false);    // Turn off fans
             }
             else
             {
                 // Turn off heaters and increase fan activity
                 await SetAllHeaters(client, 0); // Turn off heaters
-                await SetAllFans(client, true); // Turn on fans
+                await fanService.SetAllFansAsync(true);     // Turn on fans
             }
 
             // Wait for a second and fetch the updated temperature
@@ -477,7 +440,7 @@ class Program
         return currentTemperature;
     }
 
-    static async Task<double> HoldTemperature(HttpClient client, IEnumerable<ISensor> sensors, double currentTemperature, double targetTemperature, int durationSeconds)
+    static async Task<double> HoldTemperature(HttpClient client, IFanService fanService, IEnumerable<ISensor> sensors, double currentTemperature, double targetTemperature, int durationSeconds)
     {
         Console.WriteLine($"Holding temperature at {targetTemperature}°C for {durationSeconds} seconds...");
         int intervalMs = 1000; // 1-second intervals
@@ -488,13 +451,13 @@ class Program
             {
                 // Turn on heaters slightly and reduce fans
                 await SetAllHeaters(client, 1); // Minimal heating
-                await SetAllFans(client, false); // Reduce cooling
+                await fanService.SetAllFansAsync(false); // Reduce cooling
             }
             else if (currentTemperature > targetTemperature)
             {
                 // Turn off heaters and increase fans
                 await SetAllHeaters(client, 0); // Turn off heating
-                await SetAllFans(client, true); // Activate cooling
+                await fanService.SetAllFansAsync(true); // Activate cooling
             }
 
             // Wait for a second and fetch the updated temperature
@@ -533,15 +496,7 @@ class Program
         }
     }
 
-    static async Task SetAllFans(HttpClient client, bool state)
-    {
-        for (int i = 1; i <= 3; i++) // Assuming 3 fans
-        {
-            await SetFanState(client, i, state);
-        }
-    }
 
- 
 
     static async Task SetHeaterLevel(HttpClient client, int heaterId, int level)
     {
@@ -550,16 +505,6 @@ class Program
         if (!response.IsSuccessStatusCode)
         {
             throw new Exception($"Failed to set heater level {heaterId}: {response.ReasonPhrase}");
-        }
-    }
-
-    static async Task SetFanState(HttpClient client, int fanId, bool isOn)
-    {
-        var response = await client.PostAsync($"api/fans/{fanId}",
-            new StringContent(isOn.ToString().ToLower(), System.Text.Encoding.UTF8, "application/json"));
-        if (!response.IsSuccessStatusCode)
-        {
-            throw new Exception($"Failed to set fan state for fan {fanId}: {response.ReasonPhrase}");
         }
     }
 

--- a/Services/FanService.cs
+++ b/Services/FanService.cs
@@ -1,0 +1,99 @@
+using System.Text;
+using System.Text.Json;
+using UglyClient.Models;
+
+namespace UglyClient.Services;
+
+/// <summary>
+/// Concrete implementation of <see cref="IFanService"/> that communicates with the environment
+/// simulation API via an injected <see cref="HttpClient"/>.
+/// All fan-related HTTP calls and their error handling are encapsulated here; no other class
+/// should make raw HTTP calls for fan operations.
+/// </summary>
+public class FanService : IFanService
+{
+    /// <summary>
+    /// The HTTP client used to communicate with the simulation API.
+    /// Must have its <see cref="HttpClient.BaseAddress"/> set before being injected.
+    /// </summary>
+    private readonly HttpClient _client;
+
+    /// <summary>
+    /// The total number of fans managed by the simulation.
+    /// Used by <see cref="SetAllFansAsync"/> and <see cref="GetAllFanStatesAsync"/> to
+    /// iterate over all fan IDs (1 … <see cref="_fanCount"/>).
+    /// </summary>
+    private readonly int _fanCount;
+
+    /// <summary>
+    /// Shared <see cref="JsonSerializerOptions"/> configured for case-insensitive property
+    /// name matching, compatible with the simulation API's JSON responses.
+    /// </summary>
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="FanService"/> with the specified
+    /// <see cref="HttpClient"/> and optional fan count.
+    /// </summary>
+    /// <param name="client">
+    /// The pre-configured <see cref="HttpClient"/> (with <c>BaseAddress</c> and any required
+    /// headers already set). Must not be <c>null</c>.
+    /// </param>
+    /// <param name="fanCount">
+    /// The total number of fans in the simulation. Defaults to <c>3</c> when not supplied.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="client"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="fanCount"/> is less than 1.</exception>
+    public FanService(HttpClient client, int fanCount = 3)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        if (fanCount < 1)
+            throw new ArgumentOutOfRangeException(nameof(fanCount), "Fan count must be at least 1.");
+        _fanCount = fanCount;
+    }
+
+    /// <inheritdoc/>
+    public async Task SetFanStateAsync(int fanId, bool isOn)
+    {
+        var body = new StringContent(isOn.ToString().ToLower(), Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync($"api/fans/{fanId}", body);
+
+        if (!response.IsSuccessStatusCode)
+            throw new Exception($"Failed to set fan state for fan {fanId}: {response.ReasonPhrase}");
+    }
+
+    /// <inheritdoc/>
+    public async Task<FanDTO> GetFanStateAsync(int fanId)
+    {
+        var response = await _client.GetAsync($"api/fans/{fanId}/state");
+
+        if (!response.IsSuccessStatusCode)
+            throw new Exception($"Failed to get fan state for fan {fanId}: {response.ReasonPhrase}");
+
+        var json = await response.Content.ReadAsStringAsync();
+        var fan = JsonSerializer.Deserialize<FanDTO>(json, JsonOptions);
+
+        return fan ?? throw new Exception($"Fan {fanId} returned a null or unreadable response.");
+    }
+
+    /// <inheritdoc/>
+    public async Task SetAllFansAsync(bool isOn)
+    {
+        for (int i = 1; i <= _fanCount; i++)
+            await SetFanStateAsync(i, isOn);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<FanDTO>> GetAllFanStatesAsync()
+    {
+        var fans = new List<FanDTO>(_fanCount);
+
+        for (int i = 1; i <= _fanCount; i++)
+            fans.Add(await GetFanStateAsync(i));
+
+        return fans;
+    }
+}

--- a/Services/HeaterService.cs
+++ b/Services/HeaterService.cs
@@ -1,0 +1,90 @@
+using System.Text;
+
+namespace UglyClient.Services;
+
+/// <summary>
+/// Concrete implementation of <see cref="IHeaterService"/> that communicates with the environment
+/// simulation API via an injected <see cref="HttpClient"/>.
+/// All heater-related HTTP calls and their error handling are encapsulated here; no other class
+/// should make raw HTTP calls for heater operations.
+/// </summary>
+public class HeaterService : IHeaterService
+{
+    /// <summary>
+    /// The HTTP client used to communicate with the simulation API.
+    /// Must have its <see cref="HttpClient.BaseAddress"/> set before being injected.
+    /// </summary>
+    private readonly HttpClient _client;
+
+    /// <summary>
+    /// The total number of heaters managed by the simulation.
+    /// Used by <see cref="SetAllHeatersAsync"/> and <see cref="GetAllHeaterLevelsAsync"/> to
+    /// iterate over all heater IDs (1 … <see cref="_heaterCount"/>).
+    /// </summary>
+    private readonly int _heaterCount;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="HeaterService"/> with the specified
+    /// <see cref="HttpClient"/> and optional heater count.
+    /// </summary>
+    /// <param name="client">
+    /// The pre-configured <see cref="HttpClient"/> (with <c>BaseAddress</c> and any required
+    /// headers already set). Must not be <c>null</c>.
+    /// </param>
+    /// <param name="heaterCount">
+    /// The total number of heaters in the simulation. Defaults to <c>3</c> when not supplied.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="client"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="heaterCount"/> is less than 1.</exception>
+    public HeaterService(HttpClient client, int heaterCount = 3)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+        if (heaterCount < 1)
+            throw new ArgumentOutOfRangeException(nameof(heaterCount), "Heater count must be at least 1.");
+        _heaterCount = heaterCount;
+    }
+
+    /// <inheritdoc/>
+    public async Task SetHeaterLevelAsync(int heaterId, int level)
+    {
+        var body = new StringContent(level.ToString(), Encoding.UTF8, "application/json");
+        var response = await _client.PostAsync($"api/heat/{heaterId}", body);
+
+        if (!response.IsSuccessStatusCode)
+            throw new Exception($"Failed to set heater level for heater {heaterId}: {response.ReasonPhrase}");
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> GetHeaterLevelAsync(int heaterId)
+    {
+        var response = await _client.GetAsync($"api/heat/{heaterId}/level");
+
+        if (!response.IsSuccessStatusCode)
+            throw new Exception($"Failed to get heater level for heater {heaterId}: {response.ReasonPhrase}");
+
+        var body = await response.Content.ReadAsStringAsync();
+
+        if (!int.TryParse(body, out int level))
+            throw new Exception($"Heater {heaterId} returned an unreadable level response: '{body}'");
+
+        return level;
+    }
+
+    /// <inheritdoc/>
+    public async Task SetAllHeatersAsync(int level)
+    {
+        for (int i = 1; i <= _heaterCount; i++)
+            await SetHeaterLevelAsync(i, level);
+    }
+
+    /// <inheritdoc/>
+    public async Task<IEnumerable<int>> GetAllHeaterLevelsAsync()
+    {
+        var levels = new List<int>(_heaterCount);
+
+        for (int i = 1; i <= _heaterCount; i++)
+            levels.Add(await GetHeaterLevelAsync(i));
+
+        return levels;
+    }
+}

--- a/Services/IFanService.cs
+++ b/Services/IFanService.cs
@@ -1,0 +1,58 @@
+using UglyClient.Models;
+
+namespace UglyClient.Services;
+
+/// <summary>
+/// Defines the contract for all fan-related operations against the environment simulation API.
+/// Implementations must encapsulate every HTTP call and all fan-related error handling so that
+/// no <see cref="System.Net.Http.HttpClient"/> usage for fans exists outside this service.
+/// </summary>
+public interface IFanService
+{
+    /// <summary>
+    /// Sends a POST request to turn a single fan on or off.
+    /// </summary>
+    /// <param name="fanId">The one-based identifier of the fan to control.</param>
+    /// <param name="isOn"><c>true</c> to switch the fan on; <c>false</c> to switch it off.</param>
+    /// <returns>A <see cref="Task"/> that completes when the API acknowledges the command.</returns>
+    /// <exception cref="Exception">Thrown when the API returns a non-success status code.</exception>
+    Task SetFanStateAsync(int fanId, bool isOn);
+
+    /// <summary>
+    /// Sends a GET request to retrieve the current on/off state of a single fan.
+    /// </summary>
+    /// <param name="fanId">The one-based identifier of the fan to query.</param>
+    /// <returns>
+    /// A <see cref="Task{FanDTO}"/> whose result is the <see cref="FanDTO"/>
+    /// describing the fan's current state.
+    /// </returns>
+    /// <exception cref="Exception">
+    /// Thrown when the API returns a non-success status code or the response body cannot
+    /// be deserialized into a <see cref="FanDTO"/>.
+    /// </exception>
+    Task<FanDTO> GetFanStateAsync(int fanId);
+
+    /// <summary>
+    /// Sets every managed fan to the same on/off state by calling
+    /// <see cref="SetFanStateAsync"/> for each fan in sequence.
+    /// </summary>
+    /// <param name="isOn"><c>true</c> to switch all fans on; <c>false</c> to switch them all off.</param>
+    /// <returns>A <see cref="Task"/> that completes when all fans have been updated.</returns>
+    /// <exception cref="Exception">
+    /// Thrown when any individual fan command returns a non-success status code.
+    /// </exception>
+    Task SetAllFansAsync(bool isOn);
+
+    /// <summary>
+    /// Retrieves the current on/off state of every managed fan.
+    /// </summary>
+    /// <returns>
+    /// A <see cref="Task{T}"/> whose result is an <see cref="IEnumerable{FanDTO}"/>
+    /// containing one <see cref="FanDTO"/> per fan, ordered by ascending fan ID.
+    /// </returns>
+    /// <exception cref="Exception">
+    /// Thrown when any individual fan state query returns a non-success status code or
+    /// cannot be deserialized.
+    /// </exception>
+    Task<IEnumerable<FanDTO>> GetAllFanStatesAsync();
+}

--- a/Services/IHeaterService.cs
+++ b/Services/IHeaterService.cs
@@ -1,0 +1,56 @@
+namespace UglyClient.Services;
+
+/// <summary>
+/// Defines the contract for all heater-related operations against the environment simulation API.
+/// Implementations must encapsulate every HTTP call and all heater-related error handling so that
+/// no <see cref="System.Net.Http.HttpClient"/> usage for heaters exists outside this service.
+/// </summary>
+public interface IHeaterService
+{
+    /// <summary>
+    /// Sends a POST request to set the heat level of a single heater.
+    /// </summary>
+    /// <param name="heaterId">The one-based identifier of the heater to control.</param>
+    /// <param name="level">The desired heat level (0–5, where 0 is off).</param>
+    /// <returns>A <see cref="Task"/> that completes when the API acknowledges the command.</returns>
+    /// <exception cref="Exception">Thrown when the API returns a non-success status code.</exception>
+    Task SetHeaterLevelAsync(int heaterId, int level);
+
+    /// <summary>
+    /// Sends a GET request to retrieve the current heat level of a single heater.
+    /// </summary>
+    /// <param name="heaterId">The one-based identifier of the heater to query.</param>
+    /// <returns>
+    /// A <see cref="Task{T}"/> whose result is the current heat level (0–5) as an
+    /// <see cref="int"/>.
+    /// </returns>
+    /// <exception cref="Exception">
+    /// Thrown when the API returns a non-success status code or the response body cannot
+    /// be parsed as an integer.
+    /// </exception>
+    Task<int> GetHeaterLevelAsync(int heaterId);
+
+    /// <summary>
+    /// Sets every managed heater to the same level by calling
+    /// <see cref="SetHeaterLevelAsync"/> for each heater in sequence.
+    /// </summary>
+    /// <param name="level">The heat level to apply to all heaters (0–5).</param>
+    /// <returns>A <see cref="Task"/> that completes when all heaters have been updated.</returns>
+    /// <exception cref="Exception">
+    /// Thrown when any individual heater command returns a non-success status code.
+    /// </exception>
+    Task SetAllHeatersAsync(int level);
+
+    /// <summary>
+    /// Retrieves the current heat level of every managed heater.
+    /// </summary>
+    /// <returns>
+    /// A <see cref="Task{T}"/> whose result is an <see cref="IEnumerable{T}"/> of
+    /// <see cref="int"/> values, one per heater, ordered by ascending heater ID.
+    /// </returns>
+    /// <exception cref="Exception">
+    /// Thrown when any individual heater level query returns a non-success status code or
+    /// cannot be parsed.
+    /// </exception>
+    Task<IEnumerable<int>> GetAllHeaterLevelsAsync();
+}

--- a/UglyClient.Tests/Adapters/Sensor1AdapterTests.cs
+++ b/UglyClient.Tests/Adapters/Sensor1AdapterTests.cs
@@ -1,0 +1,125 @@
+using System.Net;
+using Moq;
+using Moq.Protected;
+using UglyClient.Adapters;
+using Xunit;
+
+namespace UglyClient.Tests.Adapters;
+
+/// <summary>
+/// Unit tests for <see cref="Sensor1Adapter"/>.
+/// Verifies that the adapter correctly converts the raw <see cref="string"/> HTTP response
+/// to a <see cref="double"/> and that HTTP failure paths throw the expected exceptions.
+/// </summary>
+public class Sensor1AdapterTests
+{
+    /// <summary>
+    /// Creates an <see cref="HttpClient"/> whose <see cref="HttpMessageHandler"/> is backed by
+    /// the supplied mock, allowing HTTP responses to be controlled in tests.
+    /// </summary>
+    /// <param name="handlerMock">The mocked <see cref="HttpMessageHandler"/>.</param>
+    /// <returns>An <see cref="HttpClient"/> wired to the mock handler.</returns>
+    private static HttpClient BuildClient(Mock<HttpMessageHandler> handlerMock)
+    {
+        return new HttpClient(handlerMock.Object)
+        {
+            BaseAddress = new Uri("http://test-server/")
+        };
+    }
+
+    /// <summary>
+    /// Creates a mock handler that returns the given body with the given status code.
+    /// </summary>
+    private static Mock<HttpMessageHandler> CreateHandler(HttpStatusCode statusCode, string responseBody)
+    {
+        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(responseBody)
+            });
+        return mock;
+    }
+
+    /// <summary>
+    /// When the API returns a valid numeric string, <see cref="Sensor1Adapter.GetTemperatureAsync"/>
+    /// should parse it and return the expected <see cref="double"/>.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_ValidStringResponse_ReturnsDouble()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "21.5");
+        var adapter = new Sensor1Adapter(BuildClient(handler));
+
+        // Act
+        var result = await adapter.GetTemperatureAsync();
+
+        // Assert
+        Assert.Equal(21.5, result, precision: 5);
+    }
+
+    /// <summary>
+    /// When the API returns an integer string, the adapter should still parse it correctly.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_IntegerStringResponse_ReturnsDouble()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "19");
+        var adapter = new Sensor1Adapter(BuildClient(handler));
+
+        // Act
+        var result = await adapter.GetTemperatureAsync();
+
+        // Assert
+        Assert.Equal(19.0, result, precision: 5);
+    }
+
+    /// <summary>
+    /// When the HTTP response is not a success status code, an <see cref="Exception"/> should
+    /// be thrown describing the failure.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_HttpFailure_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.ServiceUnavailable, string.Empty);
+        var adapter = new Sensor1Adapter(BuildClient(handler));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
+        Assert.Contains("Sensor 1", ex.Message);
+    }
+
+    /// <summary>
+    /// When the HTTP response body is not a parseable number, an <see cref="Exception"/>
+    /// should be thrown with an appropriate message.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_UnparsableBody_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "not-a-number");
+        var adapter = new Sensor1Adapter(BuildClient(handler));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
+        Assert.Contains("Sensor 1", ex.Message);
+    }
+
+    /// <summary>
+    /// Passing a null <see cref="HttpClient"/> to the constructor should throw
+    /// <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [Fact]
+    public void Constructor_NullClient_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new Sensor1Adapter(null!));
+    }
+}

--- a/UglyClient.Tests/Adapters/Sensor2AdapterTests.cs
+++ b/UglyClient.Tests/Adapters/Sensor2AdapterTests.cs
@@ -1,0 +1,139 @@
+using System.Net;
+using Moq;
+using Moq.Protected;
+using UglyClient.Adapters;
+using Xunit;
+
+namespace UglyClient.Tests.Adapters;
+
+/// <summary>
+/// Unit tests for <see cref="Sensor2Adapter"/>.
+/// Verifies that the adapter correctly converts the raw <see cref="int"/> HTTP response
+/// to a <see cref="double"/> and that HTTP failure paths throw the expected exceptions.
+/// </summary>
+public class Sensor2AdapterTests
+{
+    /// <summary>
+    /// Creates an <see cref="HttpClient"/> whose <see cref="HttpMessageHandler"/> is backed by
+    /// the supplied mock, allowing HTTP responses to be controlled in tests.
+    /// </summary>
+    private static HttpClient BuildClient(Mock<HttpMessageHandler> handlerMock)
+    {
+        return new HttpClient(handlerMock.Object)
+        {
+            BaseAddress = new Uri("http://test-server/")
+        };
+    }
+
+    /// <summary>
+    /// Creates a mock handler that returns the given body with the given status code.
+    /// </summary>
+    private static Mock<HttpMessageHandler> CreateHandler(HttpStatusCode statusCode, string responseBody)
+    {
+        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(responseBody)
+            });
+        return mock;
+    }
+
+    /// <summary>
+    /// When the API returns a valid integer string, <see cref="Sensor2Adapter.GetTemperatureAsync"/>
+    /// should parse it and return the expected <see cref="double"/>.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_ValidIntegerResponse_ReturnsDouble()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "22");
+        var adapter = new Sensor2Adapter(BuildClient(handler));
+
+        // Act
+        var result = await adapter.GetTemperatureAsync();
+
+        // Assert
+        Assert.Equal(22.0, result, precision: 5);
+    }
+
+    /// <summary>
+    /// Verifies that a negative integer temperature is correctly widened to a negative double.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_NegativeInteger_ReturnsNegativeDouble()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "-5");
+        var adapter = new Sensor2Adapter(BuildClient(handler));
+
+        // Act
+        var result = await adapter.GetTemperatureAsync();
+
+        // Assert
+        Assert.Equal(-5.0, result, precision: 5);
+    }
+
+    /// <summary>
+    /// When the HTTP response is not a success status code, an <see cref="Exception"/> should
+    /// be thrown describing the failure.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_HttpFailure_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.InternalServerError, string.Empty);
+        var adapter = new Sensor2Adapter(BuildClient(handler));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
+        Assert.Contains("Sensor 2", ex.Message);
+    }
+
+    /// <summary>
+    /// When the HTTP response body is a decimal (not a valid integer), an <see cref="Exception"/>
+    /// should be thrown.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_DecimalBody_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "21.7");
+        var adapter = new Sensor2Adapter(BuildClient(handler));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
+        Assert.Contains("Sensor 2", ex.Message);
+    }
+
+    /// <summary>
+    /// When the HTTP response body is not a parseable integer, an <see cref="Exception"/>
+    /// should be thrown.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_UnparsableBody_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "not-a-number");
+        var adapter = new Sensor2Adapter(BuildClient(handler));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
+        Assert.Contains("Sensor 2", ex.Message);
+    }
+
+    /// <summary>
+    /// Passing a null <see cref="HttpClient"/> to the constructor should throw
+    /// <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [Fact]
+    public void Constructor_NullClient_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new Sensor2Adapter(null!));
+    }
+}

--- a/UglyClient.Tests/Adapters/Sensor3AdapterTests.cs
+++ b/UglyClient.Tests/Adapters/Sensor3AdapterTests.cs
@@ -1,0 +1,140 @@
+using System.Net;
+using Moq;
+using Moq.Protected;
+using UglyClient.Adapters;
+using Xunit;
+
+namespace UglyClient.Tests.Adapters;
+
+/// <summary>
+/// Unit tests for <see cref="Sensor3Adapter"/>.
+/// Verifies that the adapter correctly converts the raw <see cref="decimal"/> HTTP response
+/// to a <see cref="double"/> and that HTTP failure paths throw the expected exceptions.
+/// </summary>
+public class Sensor3AdapterTests
+{
+    /// <summary>
+    /// Creates an <see cref="HttpClient"/> whose <see cref="HttpMessageHandler"/> is backed by
+    /// the supplied mock, allowing HTTP responses to be controlled in tests.
+    /// </summary>
+    private static HttpClient BuildClient(Mock<HttpMessageHandler> handlerMock)
+    {
+        return new HttpClient(handlerMock.Object)
+        {
+            BaseAddress = new Uri("http://test-server/")
+        };
+    }
+
+    /// <summary>
+    /// Creates a mock handler that returns the given body with the given status code.
+    /// </summary>
+    private static Mock<HttpMessageHandler> CreateHandler(HttpStatusCode statusCode, string responseBody)
+    {
+        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(responseBody)
+            });
+        return mock;
+    }
+
+    /// <summary>
+    /// When the API returns a valid decimal string, <see cref="Sensor3Adapter.GetTemperatureAsync"/>
+    /// should parse it and return the expected <see cref="double"/>.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_ValidDecimalResponse_ReturnsDouble()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "23.75");
+        var adapter = new Sensor3Adapter(BuildClient(handler));
+
+        // Act
+        var result = await adapter.GetTemperatureAsync();
+
+        // Assert
+        Assert.Equal(23.75, result, precision: 5);
+    }
+
+    /// <summary>
+    /// When the API returns a whole-number decimal string, it should be correctly converted.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_WholeNumberDecimalResponse_ReturnsDouble()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "18.0");
+        var adapter = new Sensor3Adapter(BuildClient(handler));
+
+        // Act
+        var result = await adapter.GetTemperatureAsync();
+
+        // Assert
+        Assert.Equal(18.0, result, precision: 5);
+    }
+
+    /// <summary>
+    /// Verifies that negative decimal temperatures are correctly handled.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_NegativeDecimal_ReturnsNegativeDouble()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "-3.5");
+        var adapter = new Sensor3Adapter(BuildClient(handler));
+
+        // Act
+        var result = await adapter.GetTemperatureAsync();
+
+        // Assert
+        Assert.Equal(-3.5, result, precision: 5);
+    }
+
+    /// <summary>
+    /// When the HTTP response is not a success status code, an <see cref="Exception"/> should
+    /// be thrown describing the failure.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_HttpFailure_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.NotFound, string.Empty);
+        var adapter = new Sensor3Adapter(BuildClient(handler));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
+        Assert.Contains("Sensor 3", ex.Message);
+    }
+
+    /// <summary>
+    /// When the HTTP response body is not a parseable decimal, an <see cref="Exception"/>
+    /// should be thrown.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_UnparsableBody_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "not-a-number");
+        var adapter = new Sensor3Adapter(BuildClient(handler));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
+        Assert.Contains("Sensor 3", ex.Message);
+    }
+
+    /// <summary>
+    /// Passing a null <see cref="HttpClient"/> to the constructor should throw
+    /// <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [Fact]
+    public void Constructor_NullClient_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new Sensor3Adapter(null!));
+    }
+}

--- a/UglyClient.Tests/Services/FanServiceTests.cs
+++ b/UglyClient.Tests/Services/FanServiceTests.cs
@@ -1,0 +1,303 @@
+using System.Net;
+using System.Text;
+using Moq;
+using Moq.Protected;
+using UglyClient.Services;
+using Xunit;
+
+namespace UglyClient.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="FanService"/>.
+/// Verifies that the service sends correctly structured HTTP requests and correctly
+/// deserializes responses or throws descriptive exceptions on failure.
+/// </summary>
+public class FanServiceTests
+{
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds an <see cref="HttpClient"/> whose transport is backed by the supplied mock
+    /// handler, with a predictable base address for URL assertions.
+    /// </summary>
+    /// <param name="handlerMock">The mocked <see cref="HttpMessageHandler"/>.</param>
+    /// <returns>An <see cref="HttpClient"/> wired to the mock handler.</returns>
+    private static HttpClient BuildClient(Mock<HttpMessageHandler> handlerMock)
+        => new HttpClient(handlerMock.Object)
+        {
+            BaseAddress = new Uri("http://test-server/")
+        };
+
+    /// <summary>
+    /// Creates a mock handler that always returns the given status code and body,
+    /// regardless of the request URI or method.
+    /// </summary>
+    /// <param name="statusCode">HTTP status code to return.</param>
+    /// <param name="responseBody">Response body text to return.</param>
+    /// <returns>A configured <see cref="Mock{HttpMessageHandler}"/>.</returns>
+    private static Mock<HttpMessageHandler> CreateHandler(HttpStatusCode statusCode, string responseBody)
+    {
+        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
+            });
+        return mock;
+    }
+
+    // ── Constructor ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Passing a null <see cref="HttpClient"/> should throw <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [Fact]
+    public void Constructor_NullClient_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new FanService(null!));
+    }
+
+    /// <summary>
+    /// Passing a fan count of zero should throw <see cref="ArgumentOutOfRangeException"/>.
+    /// </summary>
+    [Fact]
+    public void Constructor_ZeroFanCount_ThrowsArgumentOutOfRangeException()
+    {
+        var client = BuildClient(CreateHandler(HttpStatusCode.OK, string.Empty));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new FanService(client, 0));
+    }
+
+    // ── SetFanStateAsync ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// When the API returns 200 OK, <see cref="FanService.SetFanStateAsync"/> should complete
+    /// without throwing.
+    /// </summary>
+    [Fact]
+    public async Task SetFanStateAsync_SuccessResponse_DoesNotThrow()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, string.Empty);
+        var service = new FanService(BuildClient(handler));
+
+        // Act &amp; Assert — no exception expected
+        await service.SetFanStateAsync(1, true);
+    }
+
+    /// <summary>
+    /// When turning a fan ON, <see cref="FanService.SetFanStateAsync"/> must POST the body
+    /// <c>"true"</c> (lower-case) to <c>api/fans/{fanId}</c>.
+    /// </summary>
+    [Fact]
+    public async Task SetFanStateAsync_TurnOn_PostsTrueLowercase()
+    {
+        // Arrange
+        HttpRequestMessage? captured = null;
+        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK });
+
+        var service = new FanService(BuildClient(mock));
+
+        // Act
+        await service.SetFanStateAsync(2, true);
+
+        // Assert — correct endpoint and body
+        Assert.NotNull(captured);
+        Assert.Equal(HttpMethod.Post, captured!.Method);
+        Assert.EndsWith("api/fans/2", captured.RequestUri!.ToString());
+        var body = await captured.Content!.ReadAsStringAsync();
+        Assert.Equal("true", body);
+    }
+
+    /// <summary>
+    /// When turning a fan OFF, the body must be <c>"false"</c> (lower-case).
+    /// </summary>
+    [Fact]
+    public async Task SetFanStateAsync_TurnOff_PostsFalseLowercase()
+    {
+        // Arrange
+        HttpRequestMessage? captured = null;
+        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK });
+
+        var service = new FanService(BuildClient(mock));
+
+        // Act
+        await service.SetFanStateAsync(3, false);
+
+        // Assert
+        var body = await captured!.Content!.ReadAsStringAsync();
+        Assert.Equal("false", body);
+    }
+
+    /// <summary>
+    /// When the API returns a non-success status code, <see cref="FanService.SetFanStateAsync"/>
+    /// must throw an <see cref="Exception"/> that mentions the fan ID.
+    /// </summary>
+    [Fact]
+    public async Task SetFanStateAsync_HttpFailure_ThrowsExceptionWithFanId()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.ServiceUnavailable, string.Empty);
+        var service = new FanService(BuildClient(handler));
+
+        // Act &amp; Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => service.SetFanStateAsync(1, true));
+        Assert.Contains("1", ex.Message);
+    }
+
+    // ── GetFanStateAsync ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// When the API returns valid JSON, <see cref="FanService.GetFanStateAsync"/> should
+    /// deserialize it into a <see cref="UglyClient.Models.FanDTO"/> with correct values.
+    /// </summary>
+    [Fact]
+    public async Task GetFanStateAsync_ValidJson_ReturnsFanDTO()
+    {
+        // Arrange
+        const string json = """{"Id":2,"IsOn":true}""";
+        var handler = CreateHandler(HttpStatusCode.OK, json);
+        var service = new FanService(BuildClient(handler));
+
+        // Act
+        var fan = await service.GetFanStateAsync(2);
+
+        // Assert
+        Assert.Equal(2, fan.Id);
+        Assert.True(fan.IsOn);
+    }
+
+    /// <summary>
+    /// <see cref="FanService.GetFanStateAsync"/> should GET from <c>api/fans/{fanId}/state</c>.
+    /// </summary>
+    [Fact]
+    public async Task GetFanStateAsync_CallsCorrectEndpoint()
+    {
+        // Arrange
+        HttpRequestMessage? captured = null;
+        const string json = """{"Id":1,"IsOn":false}""";
+        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            });
+
+        var service = new FanService(BuildClient(mock));
+
+        // Act
+        await service.GetFanStateAsync(1);
+
+        // Assert
+        Assert.Equal(HttpMethod.Get, captured!.Method);
+        Assert.EndsWith("api/fans/1/state", captured.RequestUri!.ToString());
+    }
+
+    /// <summary>
+    /// When the API returns a non-success status code, <see cref="FanService.GetFanStateAsync"/>
+    /// must throw an <see cref="Exception"/> that mentions the fan ID.
+    /// </summary>
+    [Fact]
+    public async Task GetFanStateAsync_HttpFailure_ThrowsExceptionWithFanId()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.NotFound, string.Empty);
+        var service = new FanService(BuildClient(handler));
+
+        // Act &amp; Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => service.GetFanStateAsync(5));
+        Assert.Contains("5", ex.Message);
+    }
+
+    // ── SetAllFansAsync ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// <see cref="FanService.SetAllFansAsync"/> must issue one POST per fan (fanCount = 2 here),
+    /// all returning 200, without throwing.
+    /// </summary>
+    [Fact]
+    public async Task SetAllFansAsync_AllSucceed_DoesNotThrow()
+    {
+        // Arrange — handler always returns 200; fanCount = 2 means exactly 2 POST calls
+        var handler = CreateHandler(HttpStatusCode.OK, string.Empty);
+        var service = new FanService(BuildClient(handler), fanCount: 2);
+
+        // Act &amp; Assert
+        await service.SetAllFansAsync(true);
+    }
+
+    /// <summary>
+    /// When any fan POST fails, <see cref="FanService.SetAllFansAsync"/> must propagate the
+    /// exception from <see cref="FanService.SetFanStateAsync"/>.
+    /// </summary>
+    [Fact]
+    public async Task SetAllFansAsync_OneFails_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.InternalServerError, string.Empty);
+        var service = new FanService(BuildClient(handler), fanCount: 3);
+
+        // Act &amp; Assert
+        await Assert.ThrowsAsync<Exception>(() => service.SetAllFansAsync(false));
+    }
+
+    // ── GetAllFanStatesAsync ───────────────────────────────────────────────────
+
+    /// <summary>
+    /// <see cref="FanService.GetAllFanStatesAsync"/> should return exactly <c>fanCount</c>
+    /// <see cref="UglyClient.Models.FanDTO"/> items when all requests succeed.
+    /// </summary>
+    [Fact]
+    public async Task GetAllFanStatesAsync_AllSucceed_ReturnsCorrectCount()
+    {
+        // Arrange — same JSON returned for every fan
+        const string json = """{"Id":1,"IsOn":true}""";
+        var handler = CreateHandler(HttpStatusCode.OK, json);
+        var service = new FanService(BuildClient(handler), fanCount: 3);
+
+        // Act
+        var fans = await service.GetAllFanStatesAsync();
+
+        // Assert
+        Assert.Equal(3, fans.Count());
+    }
+
+    /// <summary>
+    /// When any individual fan GET fails, <see cref="FanService.GetAllFanStatesAsync"/>
+    /// must propagate the exception.
+    /// </summary>
+    [Fact]
+    public async Task GetAllFanStatesAsync_OneFails_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.NotFound, string.Empty);
+        var service = new FanService(BuildClient(handler), fanCount: 2);
+
+        // Act &amp; Assert
+        await Assert.ThrowsAsync<Exception>(() => service.GetAllFanStatesAsync());
+    }
+}

--- a/UglyClient.Tests/Services/HeaterServiceTests.cs
+++ b/UglyClient.Tests/Services/HeaterServiceTests.cs
@@ -1,0 +1,305 @@
+using System.Net;
+using System.Text;
+using Moq;
+using Moq.Protected;
+using UglyClient.Services;
+using Xunit;
+
+namespace UglyClient.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="HeaterService"/>.
+/// Verifies that the service sends correctly structured HTTP requests and correctly
+/// parses responses or throws descriptive exceptions on failure.
+/// </summary>
+public class HeaterServiceTests
+{
+    // ── helpers ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds an <see cref="HttpClient"/> whose transport is backed by the supplied mock
+    /// handler, with a predictable base address for URL assertions.
+    /// </summary>
+    /// <param name="handlerMock">The mocked <see cref="HttpMessageHandler"/>.</param>
+    /// <returns>An <see cref="HttpClient"/> wired to the mock handler.</returns>
+    private static HttpClient BuildClient(Mock<HttpMessageHandler> handlerMock)
+        => new HttpClient(handlerMock.Object)
+        {
+            BaseAddress = new Uri("http://test-server/")
+        };
+
+    /// <summary>
+    /// Creates a mock handler that always returns the given status code and body,
+    /// regardless of the request URI or method.
+    /// </summary>
+    /// <param name="statusCode">HTTP status code to return.</param>
+    /// <param name="responseBody">Response body text to return.</param>
+    /// <returns>A configured <see cref="Mock{HttpMessageHandler}"/>.</returns>
+    private static Mock<HttpMessageHandler> CreateHandler(HttpStatusCode statusCode, string responseBody)
+    {
+        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
+            });
+        return mock;
+    }
+
+    // ── Constructor ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Passing a null <see cref="HttpClient"/> should throw <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [Fact]
+    public void Constructor_NullClient_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new HeaterService(null!));
+    }
+
+    /// <summary>
+    /// Passing a heater count of zero should throw <see cref="ArgumentOutOfRangeException"/>.
+    /// </summary>
+    [Fact]
+    public void Constructor_ZeroHeaterCount_ThrowsArgumentOutOfRangeException()
+    {
+        var client = BuildClient(CreateHandler(HttpStatusCode.OK, string.Empty));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new HeaterService(client, 0));
+    }
+
+    // ── SetHeaterLevelAsync ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// When the API returns 200 OK, <see cref="HeaterService.SetHeaterLevelAsync"/> should
+    /// complete without throwing.
+    /// </summary>
+    [Fact]
+    public async Task SetHeaterLevelAsync_SuccessResponse_DoesNotThrow()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, string.Empty);
+        var service = new HeaterService(BuildClient(handler));
+
+        // Act &amp; Assert — no exception expected
+        await service.SetHeaterLevelAsync(1, 3);
+    }
+
+    /// <summary>
+    /// <see cref="HeaterService.SetHeaterLevelAsync"/> must POST the integer level as a
+    /// string to <c>api/heat/{heaterId}</c>.
+    /// </summary>
+    [Fact]
+    public async Task SetHeaterLevelAsync_PostsCorrectEndpointAndBody()
+    {
+        // Arrange
+        HttpRequestMessage? captured = null;
+        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK });
+
+        var service = new HeaterService(BuildClient(mock));
+
+        // Act
+        await service.SetHeaterLevelAsync(2, 5);
+
+        // Assert
+        Assert.NotNull(captured);
+        Assert.Equal(HttpMethod.Post, captured!.Method);
+        Assert.EndsWith("api/heat/2", captured.RequestUri!.ToString());
+        var body = await captured.Content!.ReadAsStringAsync();
+        Assert.Equal("5", body);
+    }
+
+    /// <summary>
+    /// When the API returns a non-success status code, <see cref="HeaterService.SetHeaterLevelAsync"/>
+    /// must throw an <see cref="Exception"/> that mentions the heater ID.
+    /// </summary>
+    [Fact]
+    public async Task SetHeaterLevelAsync_HttpFailure_ThrowsExceptionWithHeaterId()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.ServiceUnavailable, string.Empty);
+        var service = new HeaterService(BuildClient(handler));
+
+        // Act &amp; Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => service.SetHeaterLevelAsync(1, 3));
+        Assert.Contains("1", ex.Message);
+    }
+
+    // ── GetHeaterLevelAsync ────────────────────────────────────────────────────
+
+    /// <summary>
+    /// When the API returns a valid integer string body, <see cref="HeaterService.GetHeaterLevelAsync"/>
+    /// should parse and return the correct integer value.
+    /// </summary>
+    [Fact]
+    public async Task GetHeaterLevelAsync_ValidIntegerResponse_ReturnsLevel()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "4");
+        var service = new HeaterService(BuildClient(handler));
+
+        // Act
+        var level = await service.GetHeaterLevelAsync(1);
+
+        // Assert
+        Assert.Equal(4, level);
+    }
+
+    /// <summary>
+    /// <see cref="HeaterService.GetHeaterLevelAsync"/> should GET from <c>api/heat/{heaterId}/level</c>.
+    /// </summary>
+    [Fact]
+    public async Task GetHeaterLevelAsync_CallsCorrectEndpoint()
+    {
+        // Arrange
+        HttpRequestMessage? captured = null;
+        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent("2", Encoding.UTF8, "application/json")
+            });
+
+        var service = new HeaterService(BuildClient(mock));
+
+        // Act
+        await service.GetHeaterLevelAsync(3);
+
+        // Assert
+        Assert.Equal(HttpMethod.Get, captured!.Method);
+        Assert.EndsWith("api/heat/3/level", captured.RequestUri!.ToString());
+    }
+
+    /// <summary>
+    /// When the API returns a non-success status code, <see cref="HeaterService.GetHeaterLevelAsync"/>
+    /// must throw an <see cref="Exception"/> that mentions the heater ID.
+    /// </summary>
+    [Fact]
+    public async Task GetHeaterLevelAsync_HttpFailure_ThrowsExceptionWithHeaterId()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.NotFound, string.Empty);
+        var service = new HeaterService(BuildClient(handler));
+
+        // Act &amp; Assert
+        var ex = await Assert.ThrowsAsync<Exception>(() => service.GetHeaterLevelAsync(2));
+        Assert.Contains("2", ex.Message);
+    }
+
+    /// <summary>
+    /// When the API returns a body that cannot be parsed as an integer,
+    /// <see cref="HeaterService.GetHeaterLevelAsync"/> must throw an <see cref="Exception"/>.
+    /// </summary>
+    [Fact]
+    public async Task GetHeaterLevelAsync_NonIntegerResponse_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "not-a-number");
+        var service = new HeaterService(BuildClient(handler));
+
+        // Act &amp; Assert
+        await Assert.ThrowsAsync<Exception>(() => service.GetHeaterLevelAsync(1));
+    }
+
+    // ── SetAllHeatersAsync ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// <see cref="HeaterService.SetAllHeatersAsync"/> must issue one POST per heater
+    /// (heaterCount = 2 here), all returning 200, without throwing.
+    /// </summary>
+    [Fact]
+    public async Task SetAllHeatersAsync_AllSucceed_DoesNotThrow()
+    {
+        // Arrange — handler always returns 200; heaterCount = 2 means exactly 2 POST calls
+        var handler = CreateHandler(HttpStatusCode.OK, string.Empty);
+        var service = new HeaterService(BuildClient(handler), heaterCount: 2);
+
+        // Act &amp; Assert
+        await service.SetAllHeatersAsync(3);
+    }
+
+    /// <summary>
+    /// When any heater POST fails, <see cref="HeaterService.SetAllHeatersAsync"/> must
+    /// propagate the exception from <see cref="HeaterService.SetHeaterLevelAsync"/>.
+    /// </summary>
+    [Fact]
+    public async Task SetAllHeatersAsync_OneFails_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.InternalServerError, string.Empty);
+        var service = new HeaterService(BuildClient(handler), heaterCount: 3);
+
+        // Act &amp; Assert
+        await Assert.ThrowsAsync<Exception>(() => service.SetAllHeatersAsync(0));
+    }
+
+    // ── GetAllHeaterLevelsAsync ────────────────────────────────────────────────
+
+    /// <summary>
+    /// <see cref="HeaterService.GetAllHeaterLevelsAsync"/> should return exactly
+    /// <c>heaterCount</c> integer values when all requests succeed.
+    /// </summary>
+    [Fact]
+    public async Task GetAllHeaterLevelsAsync_AllSucceed_ReturnsCorrectCount()
+    {
+        // Arrange — same level returned for every heater
+        var handler = CreateHandler(HttpStatusCode.OK, "2");
+        var service = new HeaterService(BuildClient(handler), heaterCount: 3);
+
+        // Act
+        var levels = await service.GetAllHeaterLevelsAsync();
+
+        // Assert
+        Assert.Equal(3, levels.Count());
+    }
+
+    /// <summary>
+    /// Each item returned by <see cref="HeaterService.GetAllHeaterLevelsAsync"/> should
+    /// equal the parsed integer from the API response body.
+    /// </summary>
+    [Fact]
+    public async Task GetAllHeaterLevelsAsync_AllSucceed_ReturnsCorrectValues()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.OK, "5");
+        var service = new HeaterService(BuildClient(handler), heaterCount: 2);
+
+        // Act
+        var levels = await service.GetAllHeaterLevelsAsync();
+
+        // Assert — every heater should report level 5
+        Assert.All(levels, l => Assert.Equal(5, l));
+    }
+
+    /// <summary>
+    /// When any individual heater GET fails, <see cref="HeaterService.GetAllHeaterLevelsAsync"/>
+    /// must propagate the exception.
+    /// </summary>
+    [Fact]
+    public async Task GetAllHeaterLevelsAsync_OneFails_ThrowsException()
+    {
+        // Arrange
+        var handler = CreateHandler(HttpStatusCode.NotFound, string.Empty);
+        var service = new HeaterService(BuildClient(handler), heaterCount: 2);
+
+        // Act &amp; Assert
+        await Assert.ThrowsAsync<Exception>(() => service.GetAllHeaterLevelsAsync());
+    }
+}

--- a/UglyClient.Tests/UglyClient.Tests.csproj
+++ b/UglyClient.Tests/UglyClient.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\UglyClient.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/UglyClient.csproj
+++ b/UglyClient.csproj
@@ -7,4 +7,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <!-- Exclude the test project subdirectory from the main project's compilation glob -->
+    <Compile Remove="UglyClient.Tests/**" />
+  </ItemGroup>
+
 </Project>

--- a/UglyClient.sln
+++ b/UglyClient.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.11.35312.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UglyClient", "UglyClient.csproj", "{ADC10BBC-0313-4A37-A091-3505B3D19BC1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UglyClient.Tests", "UglyClient.Tests\UglyClient.Tests.csproj", "{138E2734-C666-4DE6-9D56-E192D529B058}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{ADC10BBC-0313-4A37-A091-3505B3D19BC1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ADC10BBC-0313-4A37-A091-3505B3D19BC1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ADC10BBC-0313-4A37-A091-3505B3D19BC1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{138E2734-C666-4DE6-9D56-E192D529B058}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{138E2734-C666-4DE6-9D56-E192D529B058}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{138E2734-C666-4DE6-9D56-E192D529B058}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{138E2734-C666-4DE6-9D56-E192D529B058}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

Closes #4

Implements the Heater Controller Service using the Facade Pattern, encapsulating all heater-related HTTP calls away from `Program.cs`.

## Changes

### New files
- **`Services/IHeaterService.cs`** — interface with full XML documentation on every member:
  - `SetHeaterLevelAsync(int heaterId, int level)`
  - `GetHeaterLevelAsync(int heaterId) → Task<int>`
  - `SetAllHeatersAsync(int level)`
  - `GetAllHeaterLevelsAsync() → Task<IEnumerable<int>>`

- **`Services/HeaterService.cs`** — concrete implementation injecting `HttpClient`; accepts optional `heaterCount` parameter (defaults to 3); full XML documentation on class, constructor, all fields and methods

- **`UglyClient.Tests/Services/HeaterServiceTests.cs`** — 14 xUnit tests:
  - Constructor: null client → `ArgumentNullException`; zero count → `ArgumentOutOfRangeException`
  - `SetHeaterLevelAsync`: happy path (no throw), correct POST endpoint + body, HTTP failure throws with heater ID
  - `GetHeaterLevelAsync`: happy path parses int, correct GET endpoint, HTTP failure throws, non-integer body throws
  - `SetAllHeatersAsync`: all succeed (no throw), one fails (propagates exception)
  - `GetAllHeaterLevelsAsync`: correct count returned, correct values, one fails (propagates exception)

### Updated `Program.cs`
- Instantiates `IHeaterService heaterService = new HeaterService(client, config.HeaterCount)` after `FanService`
- Removes legacy `SetHeaterLevel(HttpClient, int, int)` and `SetAllHeaters(HttpClient, int)` static methods
- `case "2"`: uses `heaterService.SetHeaterLevelAsync(heaterId, level)`
- `case "4"` and `case "6"` inline heater loops: replaced with `heaterService.GetAllHeaterLevelsAsync()`
- `Reset()`: raw heater loop replaced with `heaterService.GetAllHeaterLevelsAsync()`; `SimulationConfig config` parameter removed; `IHeaterService heaterService` parameter added
- `AdjustTemperature()` and `HoldTemperature()`: `HttpClient client` parameter replaced with `IHeaterService heaterService`; `SetAllHeaters(client, n)` calls replaced with `heaterService.SetAllHeatersAsync(n)`
- `RunTemperatureControlLoop()`: same signature update; callers updated accordingly

## Acceptance Criteria
- [x] `IHeaterService` interface in `Services/`
- [x] `HeaterService` implements `IHeaterService`
- [x] No `HttpClient` calls outside this service for heater operations
- [x] All methods are `async`/`Task`-returning
- [x] Unit tests for the service (happy path + failure path)
- [x] Project compiles cleanly (`dotnet build` → Build succeeded)
- [x] All 44 tests pass (`dotnet test` → total: 44, failed: 0, succeeded: 44)