### PR TITLE
services: add SensorService facade for unified reads

### DIFF
--- a/Adapters/Sensor1Adapter.cs
+++ b/Adapters/Sensor1Adapter.cs
@@ -17,6 +17,11 @@ public sealed class Sensor1Adapter : ISensor
     private readonly HttpClient _client;
 
     /// <summary>
+    /// Gets the fixed identifier of Sensor 1.
+    /// </summary>
+    public int SensorId => 1;
+
+    /// <summary>
     /// Initialises a new instance of <see cref="Sensor1Adapter"/>.
     /// </summary>
     /// <param name="client">

--- a/Adapters/Sensor2Adapter.cs
+++ b/Adapters/Sensor2Adapter.cs
@@ -18,6 +18,11 @@ public sealed class Sensor2Adapter : ISensor
     private readonly HttpClient _client;
 
     /// <summary>
+    /// Gets the fixed identifier of Sensor 2.
+    /// </summary>
+    public int SensorId => 2;
+
+    /// <summary>
     /// Initialises a new instance of <see cref="Sensor2Adapter"/>.
     /// </summary>
     /// <param name="client">

--- a/Adapters/Sensor3Adapter.cs
+++ b/Adapters/Sensor3Adapter.cs
@@ -18,6 +18,11 @@ public sealed class Sensor3Adapter : ISensor
     private readonly HttpClient _client;
 
     /// <summary>
+    /// Gets the fixed identifier of Sensor 3.
+    /// </summary>
+    public int SensorId => 3;
+
+    /// <summary>
     /// Initialises a new instance of <see cref="Sensor3Adapter"/>.
     /// </summary>
     /// <param name="client">

--- a/Interfaces/ISensor.cs
+++ b/Interfaces/ISensor.cs
@@ -9,6 +9,11 @@ namespace UglyClient.Interfaces;
 public interface ISensor
 {
     /// <summary>
+    /// Gets the one-based identifier of the sensor represented by this adapter.
+    /// </summary>
+    int SensorId { get; }
+
+    /// <summary>
     /// Asynchronously retrieves the current temperature reading from the sensor.
     /// </summary>
     /// <returns>

--- a/Program.cs
+++ b/Program.cs
@@ -32,6 +32,7 @@ class Program
         ISensor sensor2Adapter = new Sensor2Adapter(client);
         ISensor sensor3Adapter = new Sensor3Adapter(client);
         ISensor[] sensorAdapters = [sensor1Adapter, sensor2Adapter, sensor3Adapter];
+        ISensorService sensorService = new SensorService(sensorAdapters);
 
         // Facade / Service layer: FanService encapsulates all fan-related HTTP calls.
         IFanService fanService = new FanService(client, config.FanCount);
@@ -54,7 +55,7 @@ class Program
             switch (input)
             {
                 case "1":
-                
+
                     Console.Write("Enter Fan Number: ");
                     if (int.TryParse(Console.ReadLine(), out int fanId))
                     {
@@ -78,7 +79,7 @@ class Program
                     }
                     break;
                 case "2":
-                    
+
                     Console.Write("Enter Heater Number: ");
                     if (int.TryParse(Console.ReadLine(), out int heaterId))
                     {
@@ -106,29 +107,18 @@ class Program
                     }
                     break;
                 case "3":
-                    
+
                     Console.Write("Enter Sensor Number: ");
                     if (int.TryParse(Console.ReadLine(), out int sensorId))
                     {
                         try
                         {
-                            ISensor? selectedAdapter = sensorId switch
-                            {
-                                1 => sensor1Adapter,
-                                2 => sensor2Adapter,
-                                3 => sensor3Adapter,
-                                _ => null
-                            };
-
-                            if (selectedAdapter is null)
-                            {
-                                Console.WriteLine($"Sensor {sensorId} not found. Valid sensors are 1, 2, or 3.");
-                            }
-                            else
-                            {
-                                double temperature = await selectedAdapter.GetTemperatureAsync();
-                                Console.WriteLine($"Sensor {sensorId} Temperature: {temperature:F1}°C");
-                            }
+                            double temperature = await sensorService.GetTemperatureAsync(sensorId);
+                            Console.WriteLine($"Sensor {sensorId} Temperature: {temperature:F1}°C");
+                        }
+                        catch (KeyNotFoundException)
+                        {
+                            Console.WriteLine($"Sensor {sensorId} not found. Valid sensors are 1, 2, or 3.");
                         }
                         catch (Exception ex)
                         {
@@ -159,14 +149,7 @@ class Program
                         Console.WriteLine("Fetching sensor temperatures individually...");
                         try
                         {
-                            var s1Temp = await sensor1Adapter.GetTemperatureAsync();
-                            Console.WriteLine($"  Sensor 1: Temperature {s1Temp:F1} (Deg)");
-
-                            var s2Temp = await sensor2Adapter.GetTemperatureAsync();
-                            Console.WriteLine($"  Sensor 2: Temperature {s2Temp:F1} (Deg)");
-
-                            var s3Temp = await sensor3Adapter.GetTemperatureAsync();
-                            Console.WriteLine($"  Sensor 3: Temperature {s3Temp:F1} (Deg)");
+                            await DisplaySensorTemperaturesAsync(sensorService, config.SensorCount);
                         }
                         catch (Exception ex)
                         {
@@ -182,21 +165,21 @@ class Program
                     //await RunTemperatureControlLoop(client);
                     Console.WriteLine("Starting temperature control algorithm...");
                     Console.Write("Provide a final Temp Value: ");
-                    double currentTemperature = await GetAverageTemperature(sensorAdapters);
+                    double currentTemperature = await sensorService.GetAverageTemperatureAsync();
                     while (true)
                     {
                         // Phase 1: Gradually increase to 20°C over 30 seconds
-                        currentTemperature = await AdjustTemperature(heaterService, fanService, sensorAdapters, currentTemperature, 20.0, 30);
+                        currentTemperature = await AdjustTemperature(heaterService, fanService, sensorService, currentTemperature, 20.0, 30);
 
                         // Phase 2: Rapidly cool to 16°C
-                        currentTemperature = await AdjustTemperature(heaterService, fanService, sensorAdapters, currentTemperature, 16.0, 10);
+                        currentTemperature = await AdjustTemperature(heaterService, fanService, sensorService, currentTemperature, 16.0, 10);
 
                         // Phase 3: Hold at 16°C for 10 seconds
-                        currentTemperature = await HoldTemperature(heaterService, fanService, sensorAdapters, currentTemperature, 16.0, 10);
+                        currentTemperature = await HoldTemperature(heaterService, fanService, sensorService, currentTemperature, 16.0, 10);
 
                         // Phase 4: Gradually return to 18°C and maintain
-                        currentTemperature = await AdjustTemperature(heaterService, fanService, sensorAdapters, currentTemperature, 18.0, 20);
-                        currentTemperature = await HoldTemperature(heaterService, fanService, sensorAdapters, currentTemperature, 18.0, int.MaxValue); // Maintain until exit
+                        currentTemperature = await AdjustTemperature(heaterService, fanService, sensorService, currentTemperature, 18.0, 20);
+                        currentTemperature = await HoldTemperature(heaterService, fanService, sensorService, currentTemperature, 18.0, int.MaxValue); // Maintain until exit
                     }
                 case "6":
                     // await Reset(client);
@@ -233,14 +216,7 @@ class Program
                                 Console.WriteLine("Fetching sensor temperatures individually...");
                                 try
                                 {
-                                    var s1Temp = await sensor1Adapter.GetTemperatureAsync();
-                                    Console.WriteLine($"  Sensor 1: Temperature {s1Temp:F1} (Deg)");
-
-                                    var s2Temp = await sensor2Adapter.GetTemperatureAsync();
-                                    Console.WriteLine($"  Sensor 2: Temperature {s2Temp:F1} (Deg)");
-
-                                    var s3Temp = await sensor3Adapter.GetTemperatureAsync();
-                                    Console.WriteLine($"  Sensor 3: Temperature {s3Temp:F1} (Deg)");
+                                    await DisplaySensorTemperaturesAsync(sensorService, config.SensorCount);
                                 }
                                 catch (Exception ex)
                                 {
@@ -271,75 +247,17 @@ class Program
         }
     }
 
-    private static async Task Reset(HttpClient client, IHeaterService heaterService, IFanService fanService, IEnumerable<ISensor> sensors)
-    {
-        Console.WriteLine("Resetting client state...");
-
-        try
-        {
-            // Send a POST request to the reset endpoint
-            var response = await client.PostAsync("api/Envo/reset", null);
-
-            if (response.IsSuccessStatusCode)
-            {
-                Console.WriteLine("Client state has been successfully reset.");
-                Console.WriteLine("Fetching the state of all devices...");
-
-                try
-                {
-                    // Get individual fan states
-                    Console.WriteLine("Fetching fan states individually...");
-                    foreach (var fan in await fanService.GetAllFanStatesAsync())
-                    {
-                        Console.WriteLine($"  Fan {fan.Id}: {(fan.IsOn ? "On" : "Off")}");
-                    }
-
-                    // Get individual heater levels
-                    Console.WriteLine("Fetching heater levels individually...");
-                    int heaterIndexReset = 1;
-                    foreach (var heaterLevel in await heaterService.GetAllHeaterLevelsAsync())
-                    {
-                        Console.WriteLine($"  Heater {heaterIndexReset++}: Level {heaterLevel}");
-                    }
-
-                    // Get individual sensor temperatures
-                    Console.WriteLine("Fetching sensor temperatures individually...");
-                    try
-                    {
-                        int sensorIndex = 1;
-                        foreach (var sensor in sensors)
-                        {
-                            var temp = await sensor.GetTemperatureAsync();
-                            Console.WriteLine($"  Sensor {sensorIndex}: Temperature {temp:F1} (Deg)");
-                            sensorIndex++;
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.WriteLine($"Error fetching sensor data: {ex.Message}");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"Error fetching device states: {ex.Message}");
-                }
-            }
-            else
-            {
-                Console.WriteLine($"Failed to reset client state: {response.ReasonPhrase}");
-            }
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Error while resetting client state: {ex.Message}");
-        }
-    }
-
-    static async Task RunTemperatureControlLoop(IHeaterService heaterService, IFanService fanService, IEnumerable<ISensor> sensors)
+    /// <summary>
+    /// Runs the interactive temperature-control loop using the heater, fan, and sensor facades.
+    /// </summary>
+    /// <param name="heaterService">The heater facade used to control all heaters.</param>
+    /// <param name="fanService">The fan facade used to control all fans.</param>
+    /// <param name="sensorService">The sensor facade used to read current temperatures.</param>
+    static async Task RunTemperatureControlLoop(IHeaterService heaterService, IFanService fanService, ISensorService sensorService)
     {
         Console.WriteLine("Starting temperature control algorithm...");
 
-        double currentTemperature = await GetAverageTemperature(sensors);
+        double currentTemperature = await sensorService.GetAverageTemperatureAsync();
 
         // Prompt user for the final target temperature in Phase 4
         Console.Write("Enter the final target temperature for Phase 4: ");
@@ -352,21 +270,31 @@ class Program
         while (true)
         {
             // Phase 1: Gradually increase to 20°C over 30 seconds
-            currentTemperature = await AdjustTemperature(heaterService, fanService, sensors, currentTemperature, 20.0, 30);
+            currentTemperature = await AdjustTemperature(heaterService, fanService, sensorService, currentTemperature, 20.0, 30);
 
             // Phase 2: Rapidly cool to 16°C
-            currentTemperature = await AdjustTemperature(heaterService, fanService, sensors, currentTemperature, 16.0, 10);
+            currentTemperature = await AdjustTemperature(heaterService, fanService, sensorService, currentTemperature, 16.0, 10);
 
             // Phase 3: Hold at 16°C for 10 seconds
-            currentTemperature = await HoldTemperature(heaterService, fanService, sensors, currentTemperature, 16.0, 10);
+            currentTemperature = await HoldTemperature(heaterService, fanService, sensorService, currentTemperature, 16.0, 10);
 
             // Phase 4: Gradually adjust to the user-defined target temperature and maintain
-            currentTemperature = await AdjustTemperature(heaterService, fanService, sensors, currentTemperature, finalTargetTemperature, 20);
-            currentTemperature = await HoldTemperature(heaterService, fanService, sensors, currentTemperature, finalTargetTemperature, int.MaxValue); // Maintain until exit
+            currentTemperature = await AdjustTemperature(heaterService, fanService, sensorService, currentTemperature, finalTargetTemperature, 20);
+            currentTemperature = await HoldTemperature(heaterService, fanService, sensorService, currentTemperature, finalTargetTemperature, int.MaxValue); // Maintain until exit
         }
     }
 
-    static async Task<double> AdjustTemperature(IHeaterService heaterService, IFanService fanService, IEnumerable<ISensor> sensors, double currentTemperature, double targetTemperature, int durationSeconds)
+    /// <summary>
+    /// Gradually moves the environment temperature toward a target over a bounded duration.
+    /// </summary>
+    /// <param name="heaterService">The heater facade used to raise temperature.</param>
+    /// <param name="fanService">The fan facade used to lower temperature.</param>
+    /// <param name="sensorService">The sensor facade used to read average temperature.</param>
+    /// <param name="currentTemperature">The current average temperature before the adjustment loop starts.</param>
+    /// <param name="targetTemperature">The target average temperature.</param>
+    /// <param name="durationSeconds">The maximum number of one-second adjustment iterations to run.</param>
+    /// <returns>The final average temperature observed when the loop ends.</returns>
+    static async Task<double> AdjustTemperature(IHeaterService heaterService, IFanService fanService, ISensorService sensorService, double currentTemperature, double targetTemperature, int durationSeconds)
     {
         Console.WriteLine($"Adjusting temperature to {targetTemperature}°C over {durationSeconds} seconds...");
         int intervalMs = 1000; // 1-second intervals
@@ -391,14 +319,24 @@ class Program
 
             // Wait for a second and fetch the updated temperature
             await Task.Delay(intervalMs);
-            currentTemperature = await GetAverageTemperature(sensors);
+            currentTemperature = await sensorService.GetAverageTemperatureAsync();
             Console.WriteLine($"Current Temperature: {currentTemperature:F1}°C");
         }
 
         return currentTemperature;
     }
 
-    static async Task<double> HoldTemperature(IHeaterService heaterService, IFanService fanService, IEnumerable<ISensor> sensors, double currentTemperature, double targetTemperature, int durationSeconds)
+    /// <summary>
+    /// Attempts to maintain the environment near a target temperature for a duration.
+    /// </summary>
+    /// <param name="heaterService">The heater facade used to apply corrective heating.</param>
+    /// <param name="fanService">The fan facade used to apply corrective cooling.</param>
+    /// <param name="sensorService">The sensor facade used to read average temperature.</param>
+    /// <param name="currentTemperature">The current average temperature before the hold loop starts.</param>
+    /// <param name="targetTemperature">The target average temperature to maintain.</param>
+    /// <param name="durationSeconds">The number of one-second iterations to perform.</param>
+    /// <returns>The final average temperature observed when the hold loop ends.</returns>
+    static async Task<double> HoldTemperature(IHeaterService heaterService, IFanService fanService, ISensorService sensorService, double currentTemperature, double targetTemperature, int durationSeconds)
     {
         Console.WriteLine($"Holding temperature at {targetTemperature}°C for {durationSeconds} seconds...");
         int intervalMs = 1000; // 1-second intervals
@@ -420,7 +358,7 @@ class Program
 
             // Wait for a second and fetch the updated temperature
             await Task.Delay(intervalMs);
-            currentTemperature = await GetAverageTemperature(sensors);
+            currentTemperature = await sensorService.GetAverageTemperatureAsync();
             Console.WriteLine($"Current Temperature: {currentTemperature:F1}°C");
         }
 
@@ -428,22 +366,17 @@ class Program
     }
 
     /// <summary>
-    /// Calculates the average temperature across all provided sensor adapters.
+    /// Writes the current temperature for every configured sensor to the console.
     /// </summary>
-    /// <param name="sensors">The collection of <see cref="ISensor"/> adapters to query.</param>
-    /// <returns>The mean temperature as a <see cref="double"/>.</returns>
-    static async Task<double> GetAverageTemperature(IEnumerable<ISensor> sensors)
+    /// <param name="sensorService">The sensor facade used to retrieve temperatures.</param>
+    /// <param name="sensorCount">The total number of configured sensors to display.</param>
+    static async Task DisplaySensorTemperaturesAsync(ISensorService sensorService, int sensorCount)
     {
-        double total = 0;
-        int count = 0;
-
-        foreach (var sensor in sensors)
+        for (int sensorId = 1; sensorId <= sensorCount; sensorId++)
         {
-            total += await sensor.GetTemperatureAsync();
-            count++;
+            double temperature = await sensorService.GetTemperatureAsync(sensorId);
+            Console.WriteLine($"  Sensor {sensorId}: Temperature {temperature:F1} (Deg)");
         }
-
-        return count > 0 ? total / count : 0;
     }
 
 

--- a/Services/ISensorService.cs
+++ b/Services/ISensorService.cs
@@ -1,0 +1,28 @@
+namespace UglyClient.Services;
+
+/// <summary>
+/// Defines the facade contract for sensor-related temperature retrieval.
+/// Implementations hide adapter selection and aggregation details behind a small
+/// domain-focused API that always returns temperatures as <see cref="double"/>.
+/// </summary>
+public interface ISensorService
+{
+    /// <summary>
+    /// Retrieves the current temperature from the sensor identified by <paramref name="sensorId"/>.
+    /// </summary>
+    /// <param name="sensorId">The one-based identifier of the sensor to query.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that resolves to the current sensor temperature as a
+    /// normalised <see cref="double"/>.
+    /// </returns>
+    Task<double> GetTemperatureAsync(int sensorId);
+
+    /// <summary>
+    /// Retrieves the current temperature from every managed sensor and returns the arithmetic mean.
+    /// </summary>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> that resolves to the average temperature across all sensors
+    /// as a normalised <see cref="double"/>.
+    /// </returns>
+    Task<double> GetAverageTemperatureAsync();
+}

--- a/Services/SensorService.cs
+++ b/Services/SensorService.cs
@@ -1,0 +1,83 @@
+using UglyClient.Interfaces;
+
+namespace UglyClient.Services;
+
+/// <summary>
+/// Facade implementation of <see cref="ISensorService"/> that delegates temperature reads to the
+/// injected sensor adapters and exposes a unified <see cref="double"/>-based API.
+/// This class contains retrieval and aggregation only; it does not apply any business rules.
+/// </summary>
+public class SensorService : ISensorService
+{
+    /// <summary>
+    /// Lookup of sensor adapters keyed by their one-based sensor identifier.
+    /// </summary>
+    private readonly IReadOnlyDictionary<int, ISensor> _sensorsById;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="SensorService"/>.
+    /// </summary>
+    /// <param name="sensors">
+    /// The sensor adapters managed by this service. Each adapter must expose a unique
+    /// <see cref="ISensor.SensorId"/> value.
+    /// </param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="sensors"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the sequence is empty, contains a <see langword="null"/> adapter,
+    /// or contains duplicate sensor identifiers.
+    /// </exception>
+    public SensorService(IEnumerable<ISensor> sensors)
+    {
+        ArgumentNullException.ThrowIfNull(sensors);
+
+        var sensorsById = new Dictionary<int, ISensor>();
+
+        foreach (var sensor in sensors)
+        {
+            if (sensor is null)
+            {
+                throw new ArgumentException("Sensor collection must not contain null adapters.", nameof(sensors));
+            }
+
+            if (!sensorsById.TryAdd(sensor.SensorId, sensor))
+            {
+                throw new ArgumentException(
+                    $"Duplicate sensor ID detected: {sensor.SensorId}.",
+                    nameof(sensors));
+            }
+        }
+
+        if (sensorsById.Count == 0)
+        {
+            throw new ArgumentException("Sensor collection must contain at least one adapter.", nameof(sensors));
+        }
+
+        _sensorsById = sensorsById;
+    }
+
+    /// <inheritdoc />
+    public Task<double> GetTemperatureAsync(int sensorId)
+    {
+        if (!_sensorsById.TryGetValue(sensorId, out var sensor))
+        {
+            throw new KeyNotFoundException($"Sensor {sensorId} was not found.");
+        }
+
+        return sensor.GetTemperatureAsync();
+    }
+
+    /// <inheritdoc />
+    public async Task<double> GetAverageTemperatureAsync()
+    {
+        double total = 0;
+        int count = 0;
+
+        foreach (var sensor in _sensorsById.Values)
+        {
+            total += await sensor.GetTemperatureAsync();
+            count++;
+        }
+
+        return total / count;
+    }
+}

--- a/UglyClient.Tests/Services/SensorServiceTests.cs
+++ b/UglyClient.Tests/Services/SensorServiceTests.cs
@@ -1,0 +1,125 @@
+using Moq;
+using UglyClient.Interfaces;
+using UglyClient.Services;
+
+namespace UglyClient.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="SensorService"/>.
+/// Verifies adapter delegation, average calculation, guard clauses, and error propagation.
+/// </summary>
+public class SensorServiceTests
+{
+    /// <summary>
+    /// Passing a null sensor collection should throw <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [Fact]
+    public void Constructor_NullSensors_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new SensorService(null!));
+    }
+
+    /// <summary>
+    /// Passing an empty sensor collection should throw <see cref="ArgumentException"/>.
+    /// </summary>
+    [Fact]
+    public void Constructor_EmptySensors_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => new SensorService([]));
+    }
+
+    /// <summary>
+    /// Duplicate sensor identifiers should be rejected because the service must map each ID
+    /// to exactly one adapter.
+    /// </summary>
+    [Fact]
+    public void Constructor_DuplicateSensorIds_ThrowsArgumentException()
+    {
+        var sensor1 = CreateSensorMock(1, 20.0);
+        var duplicateSensor1 = CreateSensorMock(1, 22.0);
+
+        var ex = Assert.Throws<ArgumentException>(() => new SensorService([sensor1.Object, duplicateSensor1.Object]));
+
+        Assert.Contains("Duplicate sensor ID", ex.Message);
+    }
+
+    /// <summary>
+    /// <see cref="SensorService.GetTemperatureAsync"/> should delegate to the adapter matching
+    /// the requested sensor identifier.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_ValidSensorId_DelegatesToMatchingAdapter()
+    {
+        var sensor1 = CreateSensorMock(1, 20.0);
+        var sensor2 = CreateSensorMock(2, 24.5);
+        var service = new SensorService([sensor1.Object, sensor2.Object]);
+
+        var result = await service.GetTemperatureAsync(2);
+
+        Assert.Equal(24.5, result, precision: 5);
+        sensor1.Verify(s => s.GetTemperatureAsync(), Times.Never);
+        sensor2.Verify(s => s.GetTemperatureAsync(), Times.Once);
+    }
+
+    /// <summary>
+    /// Requesting a sensor ID that is not present should fail clearly.
+    /// </summary>
+    [Fact]
+    public async Task GetTemperatureAsync_InvalidSensorId_ThrowsKeyNotFoundException()
+    {
+        var sensor1 = CreateSensorMock(1, 20.0);
+        var service = new SensorService([sensor1.Object]);
+
+        var ex = await Assert.ThrowsAsync<KeyNotFoundException>(() => service.GetTemperatureAsync(3));
+
+        Assert.Contains("Sensor 3", ex.Message);
+    }
+
+    /// <summary>
+    /// <see cref="SensorService.GetAverageTemperatureAsync"/> should average all managed sensors.
+    /// </summary>
+    [Fact]
+    public async Task GetAverageTemperatureAsync_AllSensorsPresent_ReturnsAverage()
+    {
+        var sensor1 = CreateSensorMock(1, 18.0);
+        var sensor2 = CreateSensorMock(2, 21.0);
+        var sensor3 = CreateSensorMock(3, 24.0);
+        var service = new SensorService([sensor1.Object, sensor2.Object, sensor3.Object]);
+
+        var result = await service.GetAverageTemperatureAsync();
+
+        Assert.Equal(21.0, result, precision: 5);
+    }
+
+    /// <summary>
+    /// When an adapter throws while calculating the average, the exception should propagate.
+    /// </summary>
+    [Fact]
+    public async Task GetAverageTemperatureAsync_AdapterThrows_PropagatesException()
+    {
+        var sensor1 = CreateSensorMock(1, 18.0);
+        var sensor2 = new Mock<ISensor>();
+        sensor2.SetupGet(s => s.SensorId).Returns(2);
+        sensor2.Setup(s => s.GetTemperatureAsync()).ThrowsAsync(new Exception("Sensor 2 failed."));
+
+        var service = new SensorService([sensor1.Object, sensor2.Object]);
+
+        var ex = await Assert.ThrowsAsync<Exception>(() => service.GetAverageTemperatureAsync());
+
+        Assert.Contains("Sensor 2 failed", ex.Message);
+    }
+
+    /// <summary>
+    /// Builds a mock sensor adapter with a fixed identifier and temperature response.
+    /// </summary>
+    /// <param name="sensorId">The identifier exposed by the adapter.</param>
+    /// <param name="temperature">The temperature returned by <see cref="ISensor.GetTemperatureAsync"/>.</param>
+    /// <returns>A configured <see cref="Mock{ISensor}"/>.</returns>
+    private static Mock<ISensor> CreateSensorMock(int sensorId, double temperature)
+    {
+        var sensor = new Mock<ISensor>();
+        sensor.SetupGet(s => s.SensorId).Returns(sensorId);
+        sensor.Setup(s => s.GetTemperatureAsync()).ReturnsAsync(temperature);
+        return sensor;
+    }
+}


### PR DESCRIPTION
## Summary
- add `ISensorService` and `SensorService` as the sensor facade layer
- route `Program.cs` sensor reads and average-temperature orchestration through the new service
- add focused unit tests for delegation, invalid IDs, averaging, and adapter failure propagation

## Details
- added `SensorId` to `ISensor` and implemented it on the three sensor adapters so `SensorService` can map sensor IDs without brittle ordering assumptions
- replaced direct sensor adapter switching/manual enumeration in `Program.cs` with `sensorService` calls
- removed the legacy average-temperature helper from `Program.cs` because that responsibility now lives in `SensorService`

## Validation
- `dotnet format UglyClient.sln --include Program.cs Interfaces/ISensor.cs Adapters/Sensor1Adapter.cs Adapters/Sensor2Adapter.cs Adapters/Sensor3Adapter.cs Services/ISensorService.cs Services/SensorService.cs UglyClient.Tests/Services/SensorServiceTests.cs`
- `dotnet test UglyClient.sln`

Closes #5