### PR TITLE
feat: centralize client HTTP error handling (#12)

### DIFF
--- a/Adapters/Sensor1Adapter.cs
+++ b/Adapters/Sensor1Adapter.cs
@@ -1,4 +1,5 @@
 using UglyClient.Interfaces;
+using UglyClient.Services;
 
 namespace UglyClient.Adapters;
 
@@ -13,8 +14,8 @@ namespace UglyClient.Adapters;
 /// </remarks>
 public sealed class Sensor1Adapter : ISensor
 {
-    /// <summary>The shared <see cref="HttpClient"/> used to make requests to the sensor API.</summary>
-    private readonly HttpClient _client;
+    /// <summary>The shared HTTP service used to make requests to the sensor API.</summary>
+    private readonly IHttpService _httpService;
 
     /// <summary>
     /// Gets the fixed identifier of Sensor 1.
@@ -24,16 +25,15 @@ public sealed class Sensor1Adapter : ISensor
     /// <summary>
     /// Initialises a new instance of <see cref="Sensor1Adapter"/>.
     /// </summary>
-    /// <param name="client">
-    /// The <see cref="HttpClient"/> pre-configured with the base address and any
-    /// required authentication headers.
+    /// <param name="httpService">
+    /// The shared HTTP service used for sensor requests.
     /// </param>
     /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="client"/> is <see langword="null"/>.
+    /// Thrown when <paramref name="httpService"/> is <see langword="null"/>.
     /// </exception>
-    public Sensor1Adapter(HttpClient client)
+    public Sensor1Adapter(IHttpService httpService)
     {
-        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _httpService = httpService ?? throw new ArgumentNullException(nameof(httpService));
     }
 
     /// <inheritdoc />
@@ -43,18 +43,20 @@ public sealed class Sensor1Adapter : ISensor
     /// </remarks>
     public async Task<double> GetTemperatureAsync()
     {
-        var response = await _client.GetAsync("api/Sensor/sensor1");
+        string content;
 
-        if (!response.IsSuccessStatusCode)
+        try
         {
-            throw new Exception($"Failed to get temperature from Sensor 1: {response.ReasonPhrase}");
+            content = await _httpService.GetAsync("api/Sensor/sensor1");
         }
-
-        var content = await response.Content.ReadAsStringAsync();
+        catch (DeviceServiceException ex)
+        {
+            throw new DeviceServiceException("Unable to load sensor 1 right now.", ex);
+        }
 
         if (!double.TryParse(content, out double temperature))
         {
-            throw new Exception($"Failed to parse Sensor 1 temperature as a double. Raw value: '{content}'");
+            throw new DeviceServiceException("Unable to read the current temperature from sensor 1.");
         }
 
         return temperature;

--- a/Adapters/Sensor2Adapter.cs
+++ b/Adapters/Sensor2Adapter.cs
@@ -1,4 +1,5 @@
 using UglyClient.Interfaces;
+using UglyClient.Services;
 
 namespace UglyClient.Adapters;
 
@@ -14,8 +15,8 @@ namespace UglyClient.Adapters;
 /// </remarks>
 public sealed class Sensor2Adapter : ISensor
 {
-    /// <summary>The shared <see cref="HttpClient"/> used to make requests to the sensor API.</summary>
-    private readonly HttpClient _client;
+    /// <summary>The shared HTTP service used to make requests to the sensor API.</summary>
+    private readonly IHttpService _httpService;
 
     /// <summary>
     /// Gets the fixed identifier of Sensor 2.
@@ -25,16 +26,15 @@ public sealed class Sensor2Adapter : ISensor
     /// <summary>
     /// Initialises a new instance of <see cref="Sensor2Adapter"/>.
     /// </summary>
-    /// <param name="client">
-    /// The <see cref="HttpClient"/> pre-configured with the base address and any
-    /// required authentication headers.
+    /// <param name="httpService">
+    /// The shared HTTP service used for sensor requests.
     /// </param>
     /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="client"/> is <see langword="null"/>.
+    /// Thrown when <paramref name="httpService"/> is <see langword="null"/>.
     /// </exception>
-    public Sensor2Adapter(HttpClient client)
+    public Sensor2Adapter(IHttpService httpService)
     {
-        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _httpService = httpService ?? throw new ArgumentNullException(nameof(httpService));
     }
 
     /// <inheritdoc />
@@ -45,20 +45,22 @@ public sealed class Sensor2Adapter : ISensor
     /// </remarks>
     public async Task<double> GetTemperatureAsync()
     {
-        var response = await _client.GetAsync("api/Sensor/sensor2");
+        string content;
 
-        if (!response.IsSuccessStatusCode)
+        try
         {
-            throw new Exception($"Failed to get temperature from Sensor 2: {response.ReasonPhrase}");
+            content = await _httpService.GetAsync("api/Sensor/sensor2");
         }
-
-        var content = await response.Content.ReadAsStringAsync();
+        catch (DeviceServiceException ex)
+        {
+            throw new DeviceServiceException("Unable to load sensor 2 right now.", ex);
+        }
 
         if (!int.TryParse(content, out int temperature))
         {
-            throw new Exception($"Failed to parse Sensor 2 temperature as an integer. Raw value: '{content}'");
+            throw new DeviceServiceException("Unable to read the current temperature from sensor 2.");
         }
 
-        return (double)temperature;
+        return temperature;
     }
 }

--- a/Adapters/Sensor3Adapter.cs
+++ b/Adapters/Sensor3Adapter.cs
@@ -1,4 +1,5 @@
 using UglyClient.Interfaces;
+using UglyClient.Services;
 
 namespace UglyClient.Adapters;
 
@@ -14,8 +15,8 @@ namespace UglyClient.Adapters;
 /// </remarks>
 public sealed class Sensor3Adapter : ISensor
 {
-    /// <summary>The shared <see cref="HttpClient"/> used to make requests to the sensor API.</summary>
-    private readonly HttpClient _client;
+    /// <summary>The shared HTTP service used to make requests to the sensor API.</summary>
+    private readonly IHttpService _httpService;
 
     /// <summary>
     /// Gets the fixed identifier of Sensor 3.
@@ -25,16 +26,15 @@ public sealed class Sensor3Adapter : ISensor
     /// <summary>
     /// Initialises a new instance of <see cref="Sensor3Adapter"/>.
     /// </summary>
-    /// <param name="client">
-    /// The <see cref="HttpClient"/> pre-configured with the base address and any
-    /// required authentication headers.
+    /// <param name="httpService">
+    /// The shared HTTP service used for sensor requests.
     /// </param>
     /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="client"/> is <see langword="null"/>.
+    /// Thrown when <paramref name="httpService"/> is <see langword="null"/>.
     /// </exception>
-    public Sensor3Adapter(HttpClient client)
+    public Sensor3Adapter(IHttpService httpService)
     {
-        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _httpService = httpService ?? throw new ArgumentNullException(nameof(httpService));
     }
 
     /// <inheritdoc />
@@ -45,18 +45,20 @@ public sealed class Sensor3Adapter : ISensor
     /// </remarks>
     public async Task<double> GetTemperatureAsync()
     {
-        var response = await _client.GetAsync("api/Sensor/sensor3");
+        string content;
 
-        if (!response.IsSuccessStatusCode)
+        try
         {
-            throw new Exception($"Failed to get temperature from Sensor 3: {response.ReasonPhrase}");
+            content = await _httpService.GetAsync("api/Sensor/sensor3");
         }
-
-        var content = await response.Content.ReadAsStringAsync();
+        catch (DeviceServiceException ex)
+        {
+            throw new DeviceServiceException("Unable to load sensor 3 right now.", ex);
+        }
 
         if (!decimal.TryParse(content, out decimal temperature))
         {
-            throw new Exception($"Failed to parse Sensor 3 temperature as a decimal. Raw value: '{content}'");
+            throw new DeviceServiceException("Unable to read the current temperature from sensor 3.");
         }
 
         return (double)temperature;

--- a/Interfaces/ISensor.cs
+++ b/Interfaces/ISensor.cs
@@ -20,9 +20,8 @@ public interface ISensor
     /// A <see cref="Task{TResult}"/> that resolves to the sensor temperature as a
     /// <see cref="double"/> (degrees Celsius).
     /// </returns>
-    /// <exception cref="Exception">
-    /// Thrown when the HTTP request fails or the response cannot be parsed into a
-    /// valid temperature value.
+    /// <exception cref="UglyClient.Services.DeviceServiceException">
+    /// Thrown when the sensor reading cannot be retrieved successfully.
     /// </exception>
     Task<double> GetTemperatureAsync();
 }

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net.Http;
 using System.Threading.Tasks;
 using UglyClient.Adapters;
 using UglyClient.Config;
@@ -24,30 +23,25 @@ class Program
             ApiKey: "u007-key"
         );
 
-        // https://envrosym.azurewebsites.net/
-        var client = new HttpClient { BaseAddress = new Uri(config.BaseUrl) };
-        // var client = new HttpClient { BaseAddress = new Uri("https://envrosym.azurewebsites.net/") };
-
-        // Must match the API key in ApiKeyManager (dictionary key)
-        // MUST match a DICTIONARY KEY on the server:
-        client.DefaultRequestHeaders.Add("X-Api-Key", config.ApiKey);
+        using var httpService = new HttpService(config.BaseUrl, config.ApiKey);
 
         // Adapter Pattern: each sensor adapter wraps its own HTTP call and converts
         // the raw response type to double, conforming to ISensor.
-        ISensor sensor1Adapter = new Sensor1Adapter(client);
-        ISensor sensor2Adapter = new Sensor2Adapter(client);
-        ISensor sensor3Adapter = new Sensor3Adapter(client);
+        ISensor sensor1Adapter = new Sensor1Adapter(httpService);
+        ISensor sensor2Adapter = new Sensor2Adapter(httpService);
+        ISensor sensor3Adapter = new Sensor3Adapter(httpService);
         ISensor[] sensorAdapters = [sensor1Adapter, sensor2Adapter, sensor3Adapter];
         ISensorService sensorService = new SensorService(sensorAdapters);
 
         // Facade / Service layer: FanService encapsulates all fan-related HTTP calls.
-        IFanService fanService = new FanService(client, config.FanCount);
+        IFanService fanService = new FanService(httpService, config.FanCount);
 
         // Facade / Service layer: HeaterService encapsulates all heater-related HTTP calls.
-        IHeaterService heaterService = new HeaterService(client, config.HeaterCount);
+        IHeaterService heaterService = new HeaterService(httpService, config.HeaterCount);
         ITemperatureControlStrategy heatUpStrategy = new HeatUpStrategy(heaterService, fanService, sensorService);
         ITemperatureControlStrategy coolDownStrategy = new CoolDownStrategy(heaterService, fanService, sensorService);
         ITemperatureControlStrategy holdStrategy = new HoldStrategy(heaterService, fanService, sensorService);
+        ISimulationService simulationService = new SimulationService(httpService);
 
         while (true)
         {
@@ -66,7 +60,7 @@ class Program
                 case "1":
 
                     Console.Write("Enter Fan Number: ");
-                    if (int.TryParse(Console.ReadLine(), out int fanId))
+                    if (int.TryParse(Console.ReadLine(), out int fanId) && IsValidDeviceId(fanId, config.FanCount))
                     {
                         Console.Write("Turn Fan On or Off? (on/off): ");
                         var stateInput = Console.ReadLine();
@@ -77,20 +71,20 @@ class Program
                             await fanService.SetFanStateAsync(fanId, isOn);
                             Console.WriteLine($"Fan {fanId} has been turned {(isOn ? "On" : "Off")}.");
                         }
-                        catch (Exception ex)
+                        catch (DeviceServiceException ex)
                         {
-                            Console.WriteLine($"Error: {ex.Message}");
+                            Console.WriteLine(ex.Message);
                         }
                     }
                     else
                     {
-                        Console.WriteLine("Invalid Fan Number.");
+                        Console.WriteLine($"Invalid Fan Number. Please enter a value between 1 and {config.FanCount}.");
                     }
                     break;
                 case "2":
 
                     Console.Write("Enter Heater Number: ");
-                    if (int.TryParse(Console.ReadLine(), out int heaterId))
+                    if (int.TryParse(Console.ReadLine(), out int heaterId) && IsValidDeviceId(heaterId, config.HeaterCount))
                     {
                         Console.Write("Set Heater Level (0-5): ");
                         if (int.TryParse(Console.ReadLine(), out int level) && level >= 0 && level <= 5)
@@ -100,9 +94,9 @@ class Program
                                 await heaterService.SetHeaterLevelAsync(heaterId, level);
                                 Console.WriteLine($"Heater {heaterId} level set to {level}.");
                             }
-                            catch (Exception ex)
+                            catch (DeviceServiceException ex)
                             {
-                                Console.WriteLine($"Error: {ex.Message}");
+                                Console.WriteLine(ex.Message);
                             }
                         }
                         else
@@ -112,31 +106,27 @@ class Program
                     }
                     else
                     {
-                        Console.WriteLine("Invalid Heater Number.");
+                        Console.WriteLine($"Invalid Heater Number. Please enter a value between 1 and {config.HeaterCount}.");
                     }
                     break;
                 case "3":
 
                     Console.Write("Enter Sensor Number: ");
-                    if (int.TryParse(Console.ReadLine(), out int sensorId))
+                    if (int.TryParse(Console.ReadLine(), out int sensorId) && IsValidDeviceId(sensorId, config.SensorCount))
                     {
                         try
                         {
                             double temperature = await sensorService.GetTemperatureAsync(sensorId);
                             Console.WriteLine($"Sensor {sensorId} Temperature: {temperature:F1}°C");
                         }
-                        catch (KeyNotFoundException)
+                        catch (DeviceServiceException ex)
                         {
-                            Console.WriteLine($"Sensor {sensorId} not found. Valid sensors are 1, 2, or 3.");
-                        }
-                        catch (Exception ex)
-                        {
-                            Console.WriteLine($"Error: {ex.Message}");
+                            Console.WriteLine(ex.Message);
                         }
                     }
                     else
                     {
-                        Console.WriteLine("Invalid Sensor Number.");
+                        Console.WriteLine($"Invalid Sensor Number. Please enter a value between 1 and {config.SensorCount}.");
                     }
                     break;
                 case "4":
@@ -146,45 +136,34 @@ class Program
                     {
                         await DisplayAllDeviceStatesAsync(fanService, heaterService, sensorService, config.SensorCount);
                     }
-                    catch (Exception ex)
+                    catch (DeviceServiceException ex)
                     {
-                        Console.WriteLine($"Error fetching device states: {ex.Message}");
+                        Console.WriteLine(ex.Message);
                     }
                     break;
                 case "5":
-                    await RunTemperatureControlLoop(sensorService, heatUpStrategy, coolDownStrategy, holdStrategy);
+                    try
+                    {
+                        await RunTemperatureControlLoop(sensorService, heatUpStrategy, coolDownStrategy, holdStrategy);
+                    }
+                    catch (DeviceServiceException ex)
+                    {
+                        Console.WriteLine(ex.Message);
+                    }
                     break;
                 case "6":
-                    // await Reset(client);
                     Console.WriteLine("Resetting client state...");
 
                     try
                     {
-                        // Send a POST request to the reset endpoint
-                        var response = await client.PostAsync("api/Envo/reset", null);
-
-                        if (response.IsSuccessStatusCode)
-                        {
-                            Console.WriteLine("Client state has been successfully reset.");
-                            Console.WriteLine("Fetching the state of all devices...");
-
-                            try
-                            {
-                                await DisplayAllDeviceStatesAsync(fanService, heaterService, sensorService, config.SensorCount);
-                            }
-                            catch (Exception ex)
-                            {
-                                Console.WriteLine($"Error fetching device states: {ex.Message}");
-                            }
-                        }
-                        else
-                        {
-                            Console.WriteLine($"Failed to reset client state: {response.ReasonPhrase}");
-                        }
+                        await simulationService.ResetAsync();
+                        Console.WriteLine("Client state has been successfully reset.");
+                        Console.WriteLine("Fetching the state of all devices...");
+                        await DisplayAllDeviceStatesAsync(fanService, heaterService, sensorService, config.SensorCount);
                     }
-                    catch (Exception ex)
+                    catch (DeviceServiceException ex)
                     {
-                        Console.WriteLine($"Error while resetting client state: {ex.Message}");
+                        Console.WriteLine(ex.Message);
                     }
                     break;
                 default:
@@ -283,17 +262,7 @@ class Program
     {
         await DisplayFanStatesAsync(fanService);
         await DisplayHeaterLevelsAsync(heaterService);
-
-        Console.WriteLine("Fetching sensor temperatures individually...");
-
-        try
-        {
-            await DisplaySensorTemperaturesAsync(sensorService, sensorCount);
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Error fetching sensor data: {ex.Message}");
-        }
+        await DisplaySensorTemperaturesAsync(sensorService, sensorCount);
     }
 
     /// <summary>
@@ -332,11 +301,24 @@ class Program
     /// <param name="sensorCount">The total number of configured sensors to display.</param>
     static async Task DisplaySensorTemperaturesAsync(ISensorService sensorService, int sensorCount)
     {
+        Console.WriteLine("Fetching sensor temperatures individually...");
+
         for (int sensorId = 1; sensorId <= sensorCount; sensorId++)
         {
             double temperature = await sensorService.GetTemperatureAsync(sensorId);
             Console.WriteLine($"  Sensor {sensorId}: Temperature {temperature:F1} (Deg)");
         }
+    }
+
+    /// <summary>
+    /// Determines whether a one-based device identifier is within the configured range.
+    /// </summary>
+    /// <param name="deviceId">The one-based device identifier to validate.</param>
+    /// <param name="deviceCount">The total number of configured devices of that type.</param>
+    /// <returns><see langword="true"/> when the identifier is valid; otherwise <see langword="false"/>.</returns>
+    static bool IsValidDeviceId(int deviceId, int deviceCount)
+    {
+        return deviceId >= 1 && deviceId <= deviceCount;
     }
 
 

--- a/Services/DeviceServiceException.cs
+++ b/Services/DeviceServiceException.cs
@@ -1,0 +1,18 @@
+namespace UglyClient.Services;
+
+/// <summary>
+/// Represents a service-layer failure while communicating with or interpreting responses from
+/// the simulation API.
+/// </summary>
+public sealed class DeviceServiceException : Exception
+{
+    /// <summary>
+    /// Initialises a new instance of <see cref="DeviceServiceException"/>.
+    /// </summary>
+    /// <param name="message">The friendly message describing the failure.</param>
+    /// <param name="innerException">The underlying cause of the failure, if available.</param>
+    public DeviceServiceException(string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+    }
+}

--- a/Services/FanService.cs
+++ b/Services/FanService.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using System.Text.Json;
 using UglyClient.Models;
 
@@ -6,17 +5,16 @@ namespace UglyClient.Services;
 
 /// <summary>
 /// Concrete implementation of <see cref="IFanService"/> that communicates with the environment
-/// simulation API via an injected <see cref="HttpClient"/>.
+/// simulation API via an injected <see cref="IHttpService"/>.
 /// All fan-related HTTP calls and their error handling are encapsulated here; no other class
 /// should make raw HTTP calls for fan operations.
 /// </summary>
 public class FanService : IFanService
 {
     /// <summary>
-    /// The HTTP client used to communicate with the simulation API.
-    /// Must have its <see cref="HttpClient.BaseAddress"/> set before being injected.
+    /// The shared HTTP service used to communicate with the simulation API.
     /// </summary>
-    private readonly HttpClient _client;
+    private readonly IHttpService _httpService;
 
     /// <summary>
     /// The total number of fans managed by the simulation.
@@ -36,20 +34,19 @@ public class FanService : IFanService
 
     /// <summary>
     /// Initialises a new instance of <see cref="FanService"/> with the specified
-    /// <see cref="HttpClient"/> and optional fan count.
+    /// <see cref="IHttpService"/> and optional fan count.
     /// </summary>
-    /// <param name="client">
-    /// The pre-configured <see cref="HttpClient"/> (with <c>BaseAddress</c> and any required
-    /// headers already set). Must not be <c>null</c>.
+    /// <param name="httpService">
+    /// The shared HTTP service used for fan requests. Must not be <see langword="null"/>.
     /// </param>
     /// <param name="fanCount">
     /// The total number of fans in the simulation. Defaults to <c>3</c> when not supplied.
     /// </param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="client"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="httpService"/> is <c>null</c>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="fanCount"/> is less than 1.</exception>
-    public FanService(HttpClient client, int fanCount = 3)
+    public FanService(IHttpService httpService, int fanCount = 3)
     {
-        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _httpService = httpService ?? throw new ArgumentNullException(nameof(httpService));
         if (fanCount < 1)
             throw new ArgumentOutOfRangeException(nameof(fanCount), "Fan count must be at least 1.");
         _fanCount = fanCount;
@@ -58,25 +55,39 @@ public class FanService : IFanService
     /// <inheritdoc/>
     public async Task SetFanStateAsync(int fanId, bool isOn)
     {
-        var body = new StringContent(isOn.ToString().ToLower(), Encoding.UTF8, "application/json");
-        var response = await _client.PostAsync($"api/fans/{fanId}", body);
-
-        if (!response.IsSuccessStatusCode)
-            throw new Exception($"Failed to set fan state for fan {fanId}: {response.ReasonPhrase}");
+        try
+        {
+            await _httpService.PostAsync($"api/fans/{fanId}", isOn.ToString().ToLowerInvariant());
+        }
+        catch (DeviceServiceException ex)
+        {
+            throw new DeviceServiceException($"Unable to update fan {fanId} right now.", ex);
+        }
     }
 
     /// <inheritdoc/>
     public async Task<FanDTO> GetFanStateAsync(int fanId)
     {
-        var response = await _client.GetAsync($"api/fans/{fanId}/state");
+        string json;
 
-        if (!response.IsSuccessStatusCode)
-            throw new Exception($"Failed to get fan state for fan {fanId}: {response.ReasonPhrase}");
+        try
+        {
+            json = await _httpService.GetAsync($"api/fans/{fanId}/state");
+        }
+        catch (DeviceServiceException ex)
+        {
+            throw new DeviceServiceException($"Unable to load fan {fanId} right now.", ex);
+        }
 
-        var json = await response.Content.ReadAsStringAsync();
-        var fan = JsonSerializer.Deserialize<FanDTO>(json, JsonOptions);
-
-        return fan ?? throw new Exception($"Fan {fanId} returned a null or unreadable response.");
+        try
+        {
+            var fan = JsonSerializer.Deserialize<FanDTO>(json, JsonOptions);
+            return fan ?? throw new DeviceServiceException($"Unable to read the current state for fan {fanId}.");
+        }
+        catch (JsonException ex)
+        {
+            throw new DeviceServiceException($"Unable to read the current state for fan {fanId}.", ex);
+        }
     }
 
     /// <inheritdoc/>

--- a/Services/HeaterService.cs
+++ b/Services/HeaterService.cs
@@ -1,20 +1,17 @@
-using System.Text;
-
 namespace UglyClient.Services;
 
 /// <summary>
 /// Concrete implementation of <see cref="IHeaterService"/> that communicates with the environment
-/// simulation API via an injected <see cref="HttpClient"/>.
+/// simulation API via an injected <see cref="IHttpService"/>.
 /// All heater-related HTTP calls and their error handling are encapsulated here; no other class
 /// should make raw HTTP calls for heater operations.
 /// </summary>
 public class HeaterService : IHeaterService
 {
     /// <summary>
-    /// The HTTP client used to communicate with the simulation API.
-    /// Must have its <see cref="HttpClient.BaseAddress"/> set before being injected.
+    /// The shared HTTP service used to communicate with the simulation API.
     /// </summary>
-    private readonly HttpClient _client;
+    private readonly IHttpService _httpService;
 
     /// <summary>
     /// The total number of heaters managed by the simulation.
@@ -25,20 +22,19 @@ public class HeaterService : IHeaterService
 
     /// <summary>
     /// Initialises a new instance of <see cref="HeaterService"/> with the specified
-    /// <see cref="HttpClient"/> and optional heater count.
+    /// <see cref="IHttpService"/> and optional heater count.
     /// </summary>
-    /// <param name="client">
-    /// The pre-configured <see cref="HttpClient"/> (with <c>BaseAddress</c> and any required
-    /// headers already set). Must not be <c>null</c>.
+    /// <param name="httpService">
+    /// The shared HTTP service used for heater requests. Must not be <see langword="null"/>.
     /// </param>
     /// <param name="heaterCount">
     /// The total number of heaters in the simulation. Defaults to <c>3</c> when not supplied.
     /// </param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="client"/> is <c>null</c>.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="httpService"/> is <c>null</c>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="heaterCount"/> is less than 1.</exception>
-    public HeaterService(HttpClient client, int heaterCount = 3)
+    public HeaterService(IHttpService httpService, int heaterCount = 3)
     {
-        _client = client ?? throw new ArgumentNullException(nameof(client));
+        _httpService = httpService ?? throw new ArgumentNullException(nameof(httpService));
         if (heaterCount < 1)
             throw new ArgumentOutOfRangeException(nameof(heaterCount), "Heater count must be at least 1.");
         _heaterCount = heaterCount;
@@ -47,25 +43,34 @@ public class HeaterService : IHeaterService
     /// <inheritdoc/>
     public async Task SetHeaterLevelAsync(int heaterId, int level)
     {
-        var body = new StringContent(level.ToString(), Encoding.UTF8, "application/json");
-        var response = await _client.PostAsync($"api/heat/{heaterId}", body);
-
-        if (!response.IsSuccessStatusCode)
-            throw new Exception($"Failed to set heater level for heater {heaterId}: {response.ReasonPhrase}");
+        try
+        {
+            await _httpService.PostAsync($"api/heat/{heaterId}", level.ToString());
+        }
+        catch (DeviceServiceException ex)
+        {
+            throw new DeviceServiceException($"Unable to update heater {heaterId} right now.", ex);
+        }
     }
 
     /// <inheritdoc/>
     public async Task<int> GetHeaterLevelAsync(int heaterId)
     {
-        var response = await _client.GetAsync($"api/heat/{heaterId}/level");
+        string body;
 
-        if (!response.IsSuccessStatusCode)
-            throw new Exception($"Failed to get heater level for heater {heaterId}: {response.ReasonPhrase}");
-
-        var body = await response.Content.ReadAsStringAsync();
+        try
+        {
+            body = await _httpService.GetAsync($"api/heat/{heaterId}/level");
+        }
+        catch (DeviceServiceException ex)
+        {
+            throw new DeviceServiceException($"Unable to load heater {heaterId} right now.", ex);
+        }
 
         if (!int.TryParse(body, out int level))
-            throw new Exception($"Heater {heaterId} returned an unreadable level response: '{body}'");
+        {
+            throw new DeviceServiceException($"Unable to read the current level for heater {heaterId}.");
+        }
 
         return level;
     }

--- a/Services/HttpService.cs
+++ b/Services/HttpService.cs
@@ -28,6 +28,12 @@ public sealed class HttpService : IHttpService, IDisposable
     private readonly HttpClient _httpClient;
 
     /// <summary>
+    /// Indicates whether this service owns the lifetime of the underlying
+    /// <see cref="HttpClient"/>.
+    /// </summary>
+    private readonly bool _ownsHttpClient;
+
+    /// <summary>
     /// Initialises a new instance of <see cref="HttpService"/>, constructing and configuring
     /// the underlying <see cref="HttpClient"/> with the supplied base URL and API key.
     /// </summary>
@@ -56,6 +62,21 @@ public sealed class HttpService : IHttpService, IDisposable
         };
 
         _httpClient.DefaultRequestHeaders.Add(ApiKeyHeaderName, apiKey);
+        _ownsHttpClient = true;
+    }
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="HttpService"/> around an existing
+    /// <see cref="HttpClient"/>.
+    /// </summary>
+    /// <param name="httpClient">The pre-configured client to use for requests.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="httpClient"/> is <see langword="null"/>.
+    /// </exception>
+    public HttpService(HttpClient httpClient)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _ownsHttpClient = false;
     }
 
     /// <summary>
@@ -63,14 +84,12 @@ public sealed class HttpService : IHttpService, IDisposable
     /// </summary>
     /// <param name="endpoint">The relative endpoint path (e.g. <c>api/fans/1</c>).</param>
     /// <returns>The response content as a raw string.</returns>
-    /// <exception cref="HttpRequestException">
-    /// Thrown when the HTTP response indicates a failure status code.
+    /// <exception cref="DeviceServiceException">
+    /// Thrown when the request cannot be completed successfully.
     /// </exception>
     public async Task<string> GetAsync(string endpoint)
     {
-        var response = await _httpClient.GetAsync(endpoint);
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsStringAsync();
+        return await SendAsync(() => new HttpRequestMessage(HttpMethod.Get, endpoint));
     }
 
     /// <summary>
@@ -80,15 +99,48 @@ public sealed class HttpService : IHttpService, IDisposable
     /// <param name="endpoint">The relative endpoint path (e.g. <c>api/fans/1/state</c>).</param>
     /// <param name="body">The JSON-serialised request body to send.</param>
     /// <returns>The response content as a raw string.</returns>
-    /// <exception cref="HttpRequestException">
-    /// Thrown when the HTTP response indicates a failure status code.
+    /// <exception cref="DeviceServiceException">
+    /// Thrown when the request cannot be completed successfully.
     /// </exception>
     public async Task<string> PostAsync(string endpoint, string body)
     {
-        var content = new StringContent(body, Encoding.UTF8, JsonMediaType);
-        var response = await _httpClient.PostAsync(endpoint, content);
-        response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsStringAsync();
+        return await SendAsync(() => new HttpRequestMessage(HttpMethod.Post, endpoint)
+        {
+            Content = new StringContent(body, Encoding.UTF8, JsonMediaType)
+        });
+    }
+
+    /// <summary>
+    /// Sends an HTTP request and normalises transport and status code failures into a
+    /// <see cref="DeviceServiceException"/>.
+    /// </summary>
+    /// <param name="createRequest">Creates the request to send.</param>
+    /// <returns>The response body as a string.</returns>
+    /// <exception cref="DeviceServiceException">
+    /// Thrown when the request fails or returns a non-success status code.
+    /// </exception>
+    private async Task<string> SendAsync(Func<HttpRequestMessage> createRequest)
+    {
+        try
+        {
+            using var request = createRequest();
+            using var response = await _httpClient.SendAsync(request);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new DeviceServiceException("The simulation service is unavailable right now.");
+            }
+
+            return await response.Content.ReadAsStringAsync();
+        }
+        catch (DeviceServiceException)
+        {
+            throw;
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new DeviceServiceException("Unable to reach the simulation service right now.", ex);
+        }
     }
 
     /// <summary>
@@ -96,6 +148,9 @@ public sealed class HttpService : IHttpService, IDisposable
     /// </summary>
     public void Dispose()
     {
-        _httpClient.Dispose();
+        if (_ownsHttpClient)
+        {
+            _httpClient.Dispose();
+        }
     }
 }

--- a/Services/IFanService.cs
+++ b/Services/IFanService.cs
@@ -15,7 +15,9 @@ public interface IFanService
     /// <param name="fanId">The one-based identifier of the fan to control.</param>
     /// <param name="isOn"><c>true</c> to switch the fan on; <c>false</c> to switch it off.</param>
     /// <returns>A <see cref="Task"/> that completes when the API acknowledges the command.</returns>
-    /// <exception cref="Exception">Thrown when the API returns a non-success status code.</exception>
+    /// <exception cref="DeviceServiceException">
+    /// Thrown when the fan update cannot be completed successfully.
+    /// </exception>
     Task SetFanStateAsync(int fanId, bool isOn);
 
     /// <summary>
@@ -26,9 +28,8 @@ public interface IFanService
     /// A <see cref="Task{FanDTO}"/> whose result is the <see cref="FanDTO"/>
     /// describing the fan's current state.
     /// </returns>
-    /// <exception cref="Exception">
-    /// Thrown when the API returns a non-success status code or the response body cannot
-    /// be deserialized into a <see cref="FanDTO"/>.
+    /// <exception cref="DeviceServiceException">
+    /// Thrown when the fan state cannot be retrieved successfully.
     /// </exception>
     Task<FanDTO> GetFanStateAsync(int fanId);
 
@@ -38,8 +39,8 @@ public interface IFanService
     /// </summary>
     /// <param name="isOn"><c>true</c> to switch all fans on; <c>false</c> to switch them all off.</param>
     /// <returns>A <see cref="Task"/> that completes when all fans have been updated.</returns>
-    /// <exception cref="Exception">
-    /// Thrown when any individual fan command returns a non-success status code.
+    /// <exception cref="DeviceServiceException">
+    /// Thrown when any individual fan update cannot be completed successfully.
     /// </exception>
     Task SetAllFansAsync(bool isOn);
 
@@ -50,9 +51,8 @@ public interface IFanService
     /// A <see cref="Task{T}"/> whose result is an <see cref="IEnumerable{FanDTO}"/>
     /// containing one <see cref="FanDTO"/> per fan, ordered by ascending fan ID.
     /// </returns>
-    /// <exception cref="Exception">
-    /// Thrown when any individual fan state query returns a non-success status code or
-    /// cannot be deserialized.
+    /// <exception cref="DeviceServiceException">
+    /// Thrown when any individual fan state cannot be retrieved successfully.
     /// </exception>
     Task<IEnumerable<FanDTO>> GetAllFanStatesAsync();
 }

--- a/Services/IHeaterService.cs
+++ b/Services/IHeaterService.cs
@@ -13,7 +13,9 @@ public interface IHeaterService
     /// <param name="heaterId">The one-based identifier of the heater to control.</param>
     /// <param name="level">The desired heat level (0–5, where 0 is off).</param>
     /// <returns>A <see cref="Task"/> that completes when the API acknowledges the command.</returns>
-    /// <exception cref="Exception">Thrown when the API returns a non-success status code.</exception>
+    /// <exception cref="DeviceServiceException">
+    /// Thrown when the heater update cannot be completed successfully.
+    /// </exception>
     Task SetHeaterLevelAsync(int heaterId, int level);
 
     /// <summary>
@@ -24,9 +26,8 @@ public interface IHeaterService
     /// A <see cref="Task{T}"/> whose result is the current heat level (0–5) as an
     /// <see cref="int"/>.
     /// </returns>
-    /// <exception cref="Exception">
-    /// Thrown when the API returns a non-success status code or the response body cannot
-    /// be parsed as an integer.
+    /// <exception cref="DeviceServiceException">
+    /// Thrown when the heater level cannot be retrieved successfully.
     /// </exception>
     Task<int> GetHeaterLevelAsync(int heaterId);
 
@@ -36,8 +37,8 @@ public interface IHeaterService
     /// </summary>
     /// <param name="level">The heat level to apply to all heaters (0–5).</param>
     /// <returns>A <see cref="Task"/> that completes when all heaters have been updated.</returns>
-    /// <exception cref="Exception">
-    /// Thrown when any individual heater command returns a non-success status code.
+    /// <exception cref="DeviceServiceException">
+    /// Thrown when any individual heater update cannot be completed successfully.
     /// </exception>
     Task SetAllHeatersAsync(int level);
 
@@ -48,9 +49,8 @@ public interface IHeaterService
     /// A <see cref="Task{T}"/> whose result is an <see cref="IEnumerable{T}"/> of
     /// <see cref="int"/> values, one per heater, ordered by ascending heater ID.
     /// </returns>
-    /// <exception cref="Exception">
-    /// Thrown when any individual heater level query returns a non-success status code or
-    /// cannot be parsed.
+    /// <exception cref="DeviceServiceException">
+    /// Thrown when any individual heater level cannot be retrieved successfully.
     /// </exception>
     Task<IEnumerable<int>> GetAllHeaterLevelsAsync();
 }

--- a/Services/IHttpService.cs
+++ b/Services/IHttpService.cs
@@ -12,7 +12,9 @@ public interface IHttpService
     /// </summary>
     /// <param name="endpoint">The relative endpoint path (e.g. "api/fans/1").</param>
     /// <returns>The response content as a raw string.</returns>
-    /// <exception cref="HttpRequestException">Thrown when the HTTP response indicates a failure status code.</exception>
+    /// <exception cref="DeviceServiceException">
+    /// Thrown when the request cannot be completed successfully.
+    /// </exception>
     Task<string> GetAsync(string endpoint);
 
     /// <summary>
@@ -22,6 +24,8 @@ public interface IHttpService
     /// <param name="endpoint">The relative endpoint path (e.g. "api/fans/1/state").</param>
     /// <param name="body">The JSON-serialised request body to send.</param>
     /// <returns>The response content as a raw string.</returns>
-    /// <exception cref="HttpRequestException">Thrown when the HTTP response indicates a failure status code.</exception>
+    /// <exception cref="DeviceServiceException">
+    /// Thrown when the request cannot be completed successfully.
+    /// </exception>
     Task<string> PostAsync(string endpoint, string body);
 }

--- a/Services/ISensorService.cs
+++ b/Services/ISensorService.cs
@@ -15,6 +15,9 @@ public interface ISensorService
     /// A <see cref="Task{TResult}"/> that resolves to the current sensor temperature as a
     /// normalised <see cref="double"/>.
     /// </returns>
+    /// <exception cref="DeviceServiceException">
+    /// Thrown when the requested sensor reading cannot be retrieved successfully.
+    /// </exception>
     Task<double> GetTemperatureAsync(int sensorId);
 
     /// <summary>
@@ -24,5 +27,8 @@ public interface ISensorService
     /// A <see cref="Task{TResult}"/> that resolves to the average temperature across all sensors
     /// as a normalised <see cref="double"/>.
     /// </returns>
+    /// <exception cref="DeviceServiceException">
+    /// Thrown when one or more sensor readings cannot be retrieved successfully.
+    /// </exception>
     Task<double> GetAverageTemperatureAsync();
 }

--- a/Services/ISimulationService.cs
+++ b/Services/ISimulationService.cs
@@ -1,0 +1,16 @@
+namespace UglyClient.Services;
+
+/// <summary>
+/// Defines the contract for simulation-wide operations against the environment API.
+/// </summary>
+public interface ISimulationService
+{
+    /// <summary>
+    /// Resets the simulation to its default state.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> that completes when the reset request succeeds.</returns>
+    /// <exception cref="DeviceServiceException">
+    /// Thrown when the reset request cannot be completed successfully.
+    /// </exception>
+    Task ResetAsync();
+}

--- a/Services/SensorService.cs
+++ b/Services/SensorService.cs
@@ -60,7 +60,7 @@ public class SensorService : ISensorService
     {
         if (!_sensorsById.TryGetValue(sensorId, out var sensor))
         {
-            throw new KeyNotFoundException($"Sensor {sensorId} was not found.");
+            throw new DeviceServiceException($"Sensor {sensorId} is not available.");
         }
 
         return sensor.GetTemperatureAsync();

--- a/Services/SimulationService.cs
+++ b/Services/SimulationService.cs
@@ -1,0 +1,37 @@
+namespace UglyClient.Services;
+
+/// <summary>
+/// Concrete implementation of <see cref="ISimulationService"/> for simulation-wide API actions.
+/// </summary>
+public sealed class SimulationService : ISimulationService
+{
+    /// <summary>
+    /// The shared HTTP service used to communicate with the simulation API.
+    /// </summary>
+    private readonly IHttpService _httpService;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="SimulationService"/>.
+    /// </summary>
+    /// <param name="httpService">The shared HTTP service used for simulation requests.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="httpService"/> is <see langword="null"/>.
+    /// </exception>
+    public SimulationService(IHttpService httpService)
+    {
+        _httpService = httpService ?? throw new ArgumentNullException(nameof(httpService));
+    }
+
+    /// <inheritdoc />
+    public async Task ResetAsync()
+    {
+        try
+        {
+            await _httpService.PostAsync("api/Envo/reset", string.Empty);
+        }
+        catch (DeviceServiceException ex)
+        {
+            throw new DeviceServiceException("Unable to reset the simulation right now.", ex);
+        }
+    }
+}

--- a/UglyClient.Tests/Adapters/Sensor1AdapterTests.cs
+++ b/UglyClient.Tests/Adapters/Sensor1AdapterTests.cs
@@ -1,125 +1,53 @@
-using System.Net;
 using Moq;
-using Moq.Protected;
 using UglyClient.Adapters;
-using Xunit;
+using UglyClient.Services;
 
 namespace UglyClient.Tests.Adapters;
 
 /// <summary>
 /// Unit tests for <see cref="Sensor1Adapter"/>.
-/// Verifies that the adapter correctly converts the raw <see cref="string"/> HTTP response
-/// to a <see cref="double"/> and that HTTP failure paths throw the expected exceptions.
 /// </summary>
 public class Sensor1AdapterTests
 {
-    /// <summary>
-    /// Creates an <see cref="HttpClient"/> whose <see cref="HttpMessageHandler"/> is backed by
-    /// the supplied mock, allowing HTTP responses to be controlled in tests.
-    /// </summary>
-    /// <param name="handlerMock">The mocked <see cref="HttpMessageHandler"/>.</param>
-    /// <returns>An <see cref="HttpClient"/> wired to the mock handler.</returns>
-    private static HttpClient BuildClient(Mock<HttpMessageHandler> handlerMock)
-    {
-        return new HttpClient(handlerMock.Object)
-        {
-            BaseAddress = new Uri("http://test-server/")
-        };
-    }
-
-    /// <summary>
-    /// Creates a mock handler that returns the given body with the given status code.
-    /// </summary>
-    private static Mock<HttpMessageHandler> CreateHandler(HttpStatusCode statusCode, string responseBody)
-    {
-        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
-        mock.Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = statusCode,
-                Content = new StringContent(responseBody)
-            });
-        return mock;
-    }
-
-    /// <summary>
-    /// When the API returns a valid numeric string, <see cref="Sensor1Adapter.GetTemperatureAsync"/>
-    /// should parse it and return the expected <see cref="double"/>.
-    /// </summary>
     [Fact]
-    public async Task GetTemperatureAsync_ValidStringResponse_ReturnsDouble()
+    public void Constructor_NullHttpService_ThrowsArgumentNullException()
     {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.OK, "21.5");
-        var adapter = new Sensor1Adapter(BuildClient(handler));
+        Assert.Throws<ArgumentNullException>(() => new Sensor1Adapter(null!));
+    }
 
-        // Act
+    [Fact]
+    public async Task GetTemperatureAsync_ValidResponse_ReturnsDouble()
+    {
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService.Setup(service => service.GetAsync("api/Sensor/sensor1")).ReturnsAsync("21.5");
+        var adapter = new Sensor1Adapter(httpService.Object);
+
         var result = await adapter.GetTemperatureAsync();
 
-        // Assert
         Assert.Equal(21.5, result, precision: 5);
     }
 
-    /// <summary>
-    /// When the API returns an integer string, the adapter should still parse it correctly.
-    /// </summary>
     [Fact]
-    public async Task GetTemperatureAsync_IntegerStringResponse_ReturnsDouble()
+    public async Task GetTemperatureAsync_WhenHttpFails_ThrowsDeviceServiceException()
     {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.OK, "19");
-        var adapter = new Sensor1Adapter(BuildClient(handler));
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService
+            .Setup(service => service.GetAsync("api/Sensor/sensor1"))
+            .ThrowsAsync(new DeviceServiceException("The simulation service is unavailable right now."));
+        var adapter = new Sensor1Adapter(httpService.Object);
 
-        // Act
-        var result = await adapter.GetTemperatureAsync();
+        var exception = await Assert.ThrowsAsync<DeviceServiceException>(() => adapter.GetTemperatureAsync());
 
-        // Assert
-        Assert.Equal(19.0, result, precision: 5);
+        Assert.True(exception.Message.Contains("sensor 1", StringComparison.OrdinalIgnoreCase));
     }
 
-    /// <summary>
-    /// When the HTTP response is not a success status code, an <see cref="Exception"/> should
-    /// be thrown describing the failure.
-    /// </summary>
     [Fact]
-    public async Task GetTemperatureAsync_HttpFailure_ThrowsException()
+    public async Task GetTemperatureAsync_WhenResponseIsInvalid_ThrowsDeviceServiceException()
     {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.ServiceUnavailable, string.Empty);
-        var adapter = new Sensor1Adapter(BuildClient(handler));
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService.Setup(service => service.GetAsync("api/Sensor/sensor1")).ReturnsAsync("not-a-number");
+        var adapter = new Sensor1Adapter(httpService.Object);
 
-        // Act & Assert
-        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
-        Assert.Contains("Sensor 1", ex.Message);
-    }
-
-    /// <summary>
-    /// When the HTTP response body is not a parseable number, an <see cref="Exception"/>
-    /// should be thrown with an appropriate message.
-    /// </summary>
-    [Fact]
-    public async Task GetTemperatureAsync_UnparsableBody_ThrowsException()
-    {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.OK, "not-a-number");
-        var adapter = new Sensor1Adapter(BuildClient(handler));
-
-        // Act & Assert
-        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
-        Assert.Contains("Sensor 1", ex.Message);
-    }
-
-    /// <summary>
-    /// Passing a null <see cref="HttpClient"/> to the constructor should throw
-    /// <see cref="ArgumentNullException"/>.
-    /// </summary>
-    [Fact]
-    public void Constructor_NullClient_ThrowsArgumentNullException()
-    {
-        Assert.Throws<ArgumentNullException>(() => new Sensor1Adapter(null!));
+        await Assert.ThrowsAsync<DeviceServiceException>(() => adapter.GetTemperatureAsync());
     }
 }

--- a/UglyClient.Tests/Adapters/Sensor2AdapterTests.cs
+++ b/UglyClient.Tests/Adapters/Sensor2AdapterTests.cs
@@ -1,139 +1,53 @@
-using System.Net;
 using Moq;
-using Moq.Protected;
 using UglyClient.Adapters;
-using Xunit;
+using UglyClient.Services;
 
 namespace UglyClient.Tests.Adapters;
 
 /// <summary>
 /// Unit tests for <see cref="Sensor2Adapter"/>.
-/// Verifies that the adapter correctly converts the raw <see cref="int"/> HTTP response
-/// to a <see cref="double"/> and that HTTP failure paths throw the expected exceptions.
 /// </summary>
 public class Sensor2AdapterTests
 {
-    /// <summary>
-    /// Creates an <see cref="HttpClient"/> whose <see cref="HttpMessageHandler"/> is backed by
-    /// the supplied mock, allowing HTTP responses to be controlled in tests.
-    /// </summary>
-    private static HttpClient BuildClient(Mock<HttpMessageHandler> handlerMock)
-    {
-        return new HttpClient(handlerMock.Object)
-        {
-            BaseAddress = new Uri("http://test-server/")
-        };
-    }
-
-    /// <summary>
-    /// Creates a mock handler that returns the given body with the given status code.
-    /// </summary>
-    private static Mock<HttpMessageHandler> CreateHandler(HttpStatusCode statusCode, string responseBody)
-    {
-        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
-        mock.Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = statusCode,
-                Content = new StringContent(responseBody)
-            });
-        return mock;
-    }
-
-    /// <summary>
-    /// When the API returns a valid integer string, <see cref="Sensor2Adapter.GetTemperatureAsync"/>
-    /// should parse it and return the expected <see cref="double"/>.
-    /// </summary>
     [Fact]
-    public async Task GetTemperatureAsync_ValidIntegerResponse_ReturnsDouble()
+    public void Constructor_NullHttpService_ThrowsArgumentNullException()
     {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.OK, "22");
-        var adapter = new Sensor2Adapter(BuildClient(handler));
+        Assert.Throws<ArgumentNullException>(() => new Sensor2Adapter(null!));
+    }
 
-        // Act
+    [Fact]
+    public async Task GetTemperatureAsync_ValidResponse_ReturnsDouble()
+    {
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService.Setup(service => service.GetAsync("api/Sensor/sensor2")).ReturnsAsync("22");
+        var adapter = new Sensor2Adapter(httpService.Object);
+
         var result = await adapter.GetTemperatureAsync();
 
-        // Assert
         Assert.Equal(22.0, result, precision: 5);
     }
 
-    /// <summary>
-    /// Verifies that a negative integer temperature is correctly widened to a negative double.
-    /// </summary>
     [Fact]
-    public async Task GetTemperatureAsync_NegativeInteger_ReturnsNegativeDouble()
+    public async Task GetTemperatureAsync_WhenHttpFails_ThrowsDeviceServiceException()
     {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.OK, "-5");
-        var adapter = new Sensor2Adapter(BuildClient(handler));
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService
+            .Setup(service => service.GetAsync("api/Sensor/sensor2"))
+            .ThrowsAsync(new DeviceServiceException("The simulation service is unavailable right now."));
+        var adapter = new Sensor2Adapter(httpService.Object);
 
-        // Act
-        var result = await adapter.GetTemperatureAsync();
+        var exception = await Assert.ThrowsAsync<DeviceServiceException>(() => adapter.GetTemperatureAsync());
 
-        // Assert
-        Assert.Equal(-5.0, result, precision: 5);
+        Assert.True(exception.Message.Contains("sensor 2", StringComparison.OrdinalIgnoreCase));
     }
 
-    /// <summary>
-    /// When the HTTP response is not a success status code, an <see cref="Exception"/> should
-    /// be thrown describing the failure.
-    /// </summary>
     [Fact]
-    public async Task GetTemperatureAsync_HttpFailure_ThrowsException()
+    public async Task GetTemperatureAsync_WhenResponseIsInvalid_ThrowsDeviceServiceException()
     {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.InternalServerError, string.Empty);
-        var adapter = new Sensor2Adapter(BuildClient(handler));
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService.Setup(service => service.GetAsync("api/Sensor/sensor2")).ReturnsAsync("21.7");
+        var adapter = new Sensor2Adapter(httpService.Object);
 
-        // Act & Assert
-        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
-        Assert.Contains("Sensor 2", ex.Message);
-    }
-
-    /// <summary>
-    /// When the HTTP response body is a decimal (not a valid integer), an <see cref="Exception"/>
-    /// should be thrown.
-    /// </summary>
-    [Fact]
-    public async Task GetTemperatureAsync_DecimalBody_ThrowsException()
-    {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.OK, "21.7");
-        var adapter = new Sensor2Adapter(BuildClient(handler));
-
-        // Act & Assert
-        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
-        Assert.Contains("Sensor 2", ex.Message);
-    }
-
-    /// <summary>
-    /// When the HTTP response body is not a parseable integer, an <see cref="Exception"/>
-    /// should be thrown.
-    /// </summary>
-    [Fact]
-    public async Task GetTemperatureAsync_UnparsableBody_ThrowsException()
-    {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.OK, "not-a-number");
-        var adapter = new Sensor2Adapter(BuildClient(handler));
-
-        // Act & Assert
-        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
-        Assert.Contains("Sensor 2", ex.Message);
-    }
-
-    /// <summary>
-    /// Passing a null <see cref="HttpClient"/> to the constructor should throw
-    /// <see cref="ArgumentNullException"/>.
-    /// </summary>
-    [Fact]
-    public void Constructor_NullClient_ThrowsArgumentNullException()
-    {
-        Assert.Throws<ArgumentNullException>(() => new Sensor2Adapter(null!));
+        await Assert.ThrowsAsync<DeviceServiceException>(() => adapter.GetTemperatureAsync());
     }
 }

--- a/UglyClient.Tests/Adapters/Sensor3AdapterTests.cs
+++ b/UglyClient.Tests/Adapters/Sensor3AdapterTests.cs
@@ -1,140 +1,53 @@
-using System.Net;
 using Moq;
-using Moq.Protected;
 using UglyClient.Adapters;
-using Xunit;
+using UglyClient.Services;
 
 namespace UglyClient.Tests.Adapters;
 
 /// <summary>
 /// Unit tests for <see cref="Sensor3Adapter"/>.
-/// Verifies that the adapter correctly converts the raw <see cref="decimal"/> HTTP response
-/// to a <see cref="double"/> and that HTTP failure paths throw the expected exceptions.
 /// </summary>
 public class Sensor3AdapterTests
 {
-    /// <summary>
-    /// Creates an <see cref="HttpClient"/> whose <see cref="HttpMessageHandler"/> is backed by
-    /// the supplied mock, allowing HTTP responses to be controlled in tests.
-    /// </summary>
-    private static HttpClient BuildClient(Mock<HttpMessageHandler> handlerMock)
-    {
-        return new HttpClient(handlerMock.Object)
-        {
-            BaseAddress = new Uri("http://test-server/")
-        };
-    }
-
-    /// <summary>
-    /// Creates a mock handler that returns the given body with the given status code.
-    /// </summary>
-    private static Mock<HttpMessageHandler> CreateHandler(HttpStatusCode statusCode, string responseBody)
-    {
-        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
-        mock.Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = statusCode,
-                Content = new StringContent(responseBody)
-            });
-        return mock;
-    }
-
-    /// <summary>
-    /// When the API returns a valid decimal string, <see cref="Sensor3Adapter.GetTemperatureAsync"/>
-    /// should parse it and return the expected <see cref="double"/>.
-    /// </summary>
     [Fact]
-    public async Task GetTemperatureAsync_ValidDecimalResponse_ReturnsDouble()
+    public void Constructor_NullHttpService_ThrowsArgumentNullException()
     {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.OK, "23.75");
-        var adapter = new Sensor3Adapter(BuildClient(handler));
+        Assert.Throws<ArgumentNullException>(() => new Sensor3Adapter(null!));
+    }
 
-        // Act
+    [Fact]
+    public async Task GetTemperatureAsync_ValidResponse_ReturnsDouble()
+    {
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService.Setup(service => service.GetAsync("api/Sensor/sensor3")).ReturnsAsync("23.75");
+        var adapter = new Sensor3Adapter(httpService.Object);
+
         var result = await adapter.GetTemperatureAsync();
 
-        // Assert
         Assert.Equal(23.75, result, precision: 5);
     }
 
-    /// <summary>
-    /// When the API returns a whole-number decimal string, it should be correctly converted.
-    /// </summary>
     [Fact]
-    public async Task GetTemperatureAsync_WholeNumberDecimalResponse_ReturnsDouble()
+    public async Task GetTemperatureAsync_WhenHttpFails_ThrowsDeviceServiceException()
     {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.OK, "18.0");
-        var adapter = new Sensor3Adapter(BuildClient(handler));
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService
+            .Setup(service => service.GetAsync("api/Sensor/sensor3"))
+            .ThrowsAsync(new DeviceServiceException("The simulation service is unavailable right now."));
+        var adapter = new Sensor3Adapter(httpService.Object);
 
-        // Act
-        var result = await adapter.GetTemperatureAsync();
+        var exception = await Assert.ThrowsAsync<DeviceServiceException>(() => adapter.GetTemperatureAsync());
 
-        // Assert
-        Assert.Equal(18.0, result, precision: 5);
+        Assert.True(exception.Message.Contains("sensor 3", StringComparison.OrdinalIgnoreCase));
     }
 
-    /// <summary>
-    /// Verifies that negative decimal temperatures are correctly handled.
-    /// </summary>
     [Fact]
-    public async Task GetTemperatureAsync_NegativeDecimal_ReturnsNegativeDouble()
+    public async Task GetTemperatureAsync_WhenResponseIsInvalid_ThrowsDeviceServiceException()
     {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.OK, "-3.5");
-        var adapter = new Sensor3Adapter(BuildClient(handler));
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService.Setup(service => service.GetAsync("api/Sensor/sensor3")).ReturnsAsync("not-a-number");
+        var adapter = new Sensor3Adapter(httpService.Object);
 
-        // Act
-        var result = await adapter.GetTemperatureAsync();
-
-        // Assert
-        Assert.Equal(-3.5, result, precision: 5);
-    }
-
-    /// <summary>
-    /// When the HTTP response is not a success status code, an <see cref="Exception"/> should
-    /// be thrown describing the failure.
-    /// </summary>
-    [Fact]
-    public async Task GetTemperatureAsync_HttpFailure_ThrowsException()
-    {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.NotFound, string.Empty);
-        var adapter = new Sensor3Adapter(BuildClient(handler));
-
-        // Act & Assert
-        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
-        Assert.Contains("Sensor 3", ex.Message);
-    }
-
-    /// <summary>
-    /// When the HTTP response body is not a parseable decimal, an <see cref="Exception"/>
-    /// should be thrown.
-    /// </summary>
-    [Fact]
-    public async Task GetTemperatureAsync_UnparsableBody_ThrowsException()
-    {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.OK, "not-a-number");
-        var adapter = new Sensor3Adapter(BuildClient(handler));
-
-        // Act & Assert
-        var ex = await Assert.ThrowsAsync<Exception>(() => adapter.GetTemperatureAsync());
-        Assert.Contains("Sensor 3", ex.Message);
-    }
-
-    /// <summary>
-    /// Passing a null <see cref="HttpClient"/> to the constructor should throw
-    /// <see cref="ArgumentNullException"/>.
-    /// </summary>
-    [Fact]
-    public void Constructor_NullClient_ThrowsArgumentNullException()
-    {
-        Assert.Throws<ArgumentNullException>(() => new Sensor3Adapter(null!));
+        await Assert.ThrowsAsync<DeviceServiceException>(() => adapter.GetTemperatureAsync());
     }
 }

--- a/UglyClient.Tests/Services/FanServiceTests.cs
+++ b/UglyClient.Tests/Services/FanServiceTests.cs
@@ -1,303 +1,118 @@
-using System.Net;
-using System.Text;
 using Moq;
-using Moq.Protected;
 using UglyClient.Services;
-using Xunit;
 
 namespace UglyClient.Tests.Services;
 
 /// <summary>
 /// Unit tests for <see cref="FanService"/>.
-/// Verifies that the service sends correctly structured HTTP requests and correctly
-/// deserializes responses or throws descriptive exceptions on failure.
 /// </summary>
 public class FanServiceTests
 {
-    // ── helpers ────────────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Builds an <see cref="HttpClient"/> whose transport is backed by the supplied mock
-    /// handler, with a predictable base address for URL assertions.
-    /// </summary>
-    /// <param name="handlerMock">The mocked <see cref="HttpMessageHandler"/>.</param>
-    /// <returns>An <see cref="HttpClient"/> wired to the mock handler.</returns>
-    private static HttpClient BuildClient(Mock<HttpMessageHandler> handlerMock)
-        => new HttpClient(handlerMock.Object)
-        {
-            BaseAddress = new Uri("http://test-server/")
-        };
-
-    /// <summary>
-    /// Creates a mock handler that always returns the given status code and body,
-    /// regardless of the request URI or method.
-    /// </summary>
-    /// <param name="statusCode">HTTP status code to return.</param>
-    /// <param name="responseBody">Response body text to return.</param>
-    /// <returns>A configured <see cref="Mock{HttpMessageHandler}"/>.</returns>
-    private static Mock<HttpMessageHandler> CreateHandler(HttpStatusCode statusCode, string responseBody)
-    {
-        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
-        mock.Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = statusCode,
-                Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
-            });
-        return mock;
-    }
-
-    // ── Constructor ────────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Passing a null <see cref="HttpClient"/> should throw <see cref="ArgumentNullException"/>.
-    /// </summary>
     [Fact]
-    public void Constructor_NullClient_ThrowsArgumentNullException()
+    public void Constructor_NullHttpService_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() => new FanService(null!));
     }
 
-    /// <summary>
-    /// Passing a fan count of zero should throw <see cref="ArgumentOutOfRangeException"/>.
-    /// </summary>
     [Fact]
     public void Constructor_ZeroFanCount_ThrowsArgumentOutOfRangeException()
     {
-        var client = BuildClient(CreateHandler(HttpStatusCode.OK, string.Empty));
-        Assert.Throws<ArgumentOutOfRangeException>(() => new FanService(client, 0));
+        var httpService = new Mock<IHttpService>();
+        Assert.Throws<ArgumentOutOfRangeException>(() => new FanService(httpService.Object, 0));
     }
 
-    // ── SetFanStateAsync ───────────────────────────────────────────────────────
-
-    /// <summary>
-    /// When the API returns 200 OK, <see cref="FanService.SetFanStateAsync"/> should complete
-    /// without throwing.
-    /// </summary>
     [Fact]
-    public async Task SetFanStateAsync_SuccessResponse_DoesNotThrow()
+    public async Task SetFanStateAsync_TurnOn_CallsExpectedEndpoint()
     {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.OK, string.Empty);
-        var service = new FanService(BuildClient(handler));
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService.Setup(service => service.PostAsync("api/fans/2", "true")).ReturnsAsync(string.Empty);
+        var fanService = new FanService(httpService.Object);
 
-        // Act &amp; Assert — no exception expected
-        await service.SetFanStateAsync(1, true);
+        await fanService.SetFanStateAsync(2, true);
+
+        httpService.VerifyAll();
     }
 
-    /// <summary>
-    /// When turning a fan ON, <see cref="FanService.SetFanStateAsync"/> must POST the body
-    /// <c>"true"</c> (lower-case) to <c>api/fans/{fanId}</c>.
-    /// </summary>
     [Fact]
-    public async Task SetFanStateAsync_TurnOn_PostsTrueLowercase()
+    public async Task SetFanStateAsync_WhenHttpFails_ThrowsDeviceServiceException()
     {
-        // Arrange
-        HttpRequestMessage? captured = null;
-        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
-        mock.Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
-            .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK });
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService
+            .Setup(service => service.PostAsync("api/fans/1", "true"))
+            .ThrowsAsync(new DeviceServiceException("The simulation service is unavailable right now."));
+        var fanService = new FanService(httpService.Object);
 
-        var service = new FanService(BuildClient(mock));
+        var exception = await Assert.ThrowsAsync<DeviceServiceException>(() => fanService.SetFanStateAsync(1, true));
 
-        // Act
-        await service.SetFanStateAsync(2, true);
-
-        // Assert — correct endpoint and body
-        Assert.NotNull(captured);
-        Assert.Equal(HttpMethod.Post, captured!.Method);
-        Assert.EndsWith("api/fans/2", captured.RequestUri!.ToString());
-        var body = await captured.Content!.ReadAsStringAsync();
-        Assert.Equal("true", body);
+        Assert.True(exception.Message.Contains("fan 1", StringComparison.OrdinalIgnoreCase));
     }
 
-    /// <summary>
-    /// When turning a fan OFF, the body must be <c>"false"</c> (lower-case).
-    /// </summary>
     [Fact]
-    public async Task SetFanStateAsync_TurnOff_PostsFalseLowercase()
+    public async Task GetFanStateAsync_ValidJson_ReturnsFanState()
     {
-        // Arrange
-        HttpRequestMessage? captured = null;
-        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
-        mock.Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
-            .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK });
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService
+            .Setup(service => service.GetAsync("api/fans/3/state"))
+            .ReturnsAsync("""{"id":3,"isOn":true}""");
+        var fanService = new FanService(httpService.Object);
 
-        var service = new FanService(BuildClient(mock));
+        var fan = await fanService.GetFanStateAsync(3);
 
-        // Act
-        await service.SetFanStateAsync(3, false);
-
-        // Assert
-        var body = await captured!.Content!.ReadAsStringAsync();
-        Assert.Equal("false", body);
-    }
-
-    /// <summary>
-    /// When the API returns a non-success status code, <see cref="FanService.SetFanStateAsync"/>
-    /// must throw an <see cref="Exception"/> that mentions the fan ID.
-    /// </summary>
-    [Fact]
-    public async Task SetFanStateAsync_HttpFailure_ThrowsExceptionWithFanId()
-    {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.ServiceUnavailable, string.Empty);
-        var service = new FanService(BuildClient(handler));
-
-        // Act &amp; Assert
-        var ex = await Assert.ThrowsAsync<Exception>(() => service.SetFanStateAsync(1, true));
-        Assert.Contains("1", ex.Message);
-    }
-
-    // ── GetFanStateAsync ───────────────────────────────────────────────────────
-
-    /// <summary>
-    /// When the API returns valid JSON, <see cref="FanService.GetFanStateAsync"/> should
-    /// deserialize it into a <see cref="UglyClient.Models.FanDTO"/> with correct values.
-    /// </summary>
-    [Fact]
-    public async Task GetFanStateAsync_ValidJson_ReturnsFanDTO()
-    {
-        // Arrange
-        const string json = """{"Id":2,"IsOn":true}""";
-        var handler = CreateHandler(HttpStatusCode.OK, json);
-        var service = new FanService(BuildClient(handler));
-
-        // Act
-        var fan = await service.GetFanStateAsync(2);
-
-        // Assert
-        Assert.Equal(2, fan.Id);
+        Assert.Equal(3, fan.Id);
         Assert.True(fan.IsOn);
     }
 
-    /// <summary>
-    /// <see cref="FanService.GetFanStateAsync"/> should GET from <c>api/fans/{fanId}/state</c>.
-    /// </summary>
     [Fact]
-    public async Task GetFanStateAsync_CallsCorrectEndpoint()
+    public async Task GetFanStateAsync_WhenHttpFails_ThrowsDeviceServiceException()
     {
-        // Arrange
-        HttpRequestMessage? captured = null;
-        const string json = """{"Id":1,"IsOn":false}""";
-        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
-        mock.Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent(json, Encoding.UTF8, "application/json")
-            });
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService
+            .Setup(service => service.GetAsync("api/fans/4/state"))
+            .ThrowsAsync(new DeviceServiceException("The simulation service is unavailable right now."));
+        var fanService = new FanService(httpService.Object);
 
-        var service = new FanService(BuildClient(mock));
+        var exception = await Assert.ThrowsAsync<DeviceServiceException>(() => fanService.GetFanStateAsync(4));
 
-        // Act
-        await service.GetFanStateAsync(1);
-
-        // Assert
-        Assert.Equal(HttpMethod.Get, captured!.Method);
-        Assert.EndsWith("api/fans/1/state", captured.RequestUri!.ToString());
+        Assert.True(exception.Message.Contains("fan 4", StringComparison.OrdinalIgnoreCase));
     }
 
-    /// <summary>
-    /// When the API returns a non-success status code, <see cref="FanService.GetFanStateAsync"/>
-    /// must throw an <see cref="Exception"/> that mentions the fan ID.
-    /// </summary>
     [Fact]
-    public async Task GetFanStateAsync_HttpFailure_ThrowsExceptionWithFanId()
+    public async Task GetFanStateAsync_WhenJsonIsInvalid_ThrowsDeviceServiceException()
     {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.NotFound, string.Empty);
-        var service = new FanService(BuildClient(handler));
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService
+            .Setup(service => service.GetAsync("api/fans/1/state"))
+            .ReturnsAsync("{not-json}");
+        var fanService = new FanService(httpService.Object);
 
-        // Act &amp; Assert
-        var ex = await Assert.ThrowsAsync<Exception>(() => service.GetFanStateAsync(5));
-        Assert.Contains("5", ex.Message);
+        await Assert.ThrowsAsync<DeviceServiceException>(() => fanService.GetFanStateAsync(1));
     }
 
-    // ── SetAllFansAsync ────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// <see cref="FanService.SetAllFansAsync"/> must issue one POST per fan (fanCount = 2 here),
-    /// all returning 200, without throwing.
-    /// </summary>
     [Fact]
-    public async Task SetAllFansAsync_AllSucceed_DoesNotThrow()
+    public async Task SetAllFansAsync_CallsEachFanEndpoint()
     {
-        // Arrange — handler always returns 200; fanCount = 2 means exactly 2 POST calls
-        var handler = CreateHandler(HttpStatusCode.OK, string.Empty);
-        var service = new FanService(BuildClient(handler), fanCount: 2);
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService.Setup(service => service.PostAsync("api/fans/1", "false")).ReturnsAsync(string.Empty);
+        httpService.Setup(service => service.PostAsync("api/fans/2", "false")).ReturnsAsync(string.Empty);
+        var fanService = new FanService(httpService.Object, fanCount: 2);
 
-        // Act &amp; Assert
-        await service.SetAllFansAsync(true);
+        await fanService.SetAllFansAsync(false);
+
+        httpService.VerifyAll();
     }
 
-    /// <summary>
-    /// When any fan POST fails, <see cref="FanService.SetAllFansAsync"/> must propagate the
-    /// exception from <see cref="FanService.SetFanStateAsync"/>.
-    /// </summary>
     [Fact]
-    public async Task SetAllFansAsync_OneFails_ThrowsException()
+    public async Task GetAllFanStatesAsync_ReturnsStateForEachFan()
     {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.InternalServerError, string.Empty);
-        var service = new FanService(BuildClient(handler), fanCount: 3);
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService.Setup(service => service.GetAsync("api/fans/1/state")).ReturnsAsync("""{"id":1,"isOn":true}""");
+        httpService.Setup(service => service.GetAsync("api/fans/2/state")).ReturnsAsync("""{"id":2,"isOn":false}""");
+        var fanService = new FanService(httpService.Object, fanCount: 2);
 
-        // Act &amp; Assert
-        await Assert.ThrowsAsync<Exception>(() => service.SetAllFansAsync(false));
-    }
+        var fans = (await fanService.GetAllFanStatesAsync()).ToList();
 
-    // ── GetAllFanStatesAsync ───────────────────────────────────────────────────
-
-    /// <summary>
-    /// <see cref="FanService.GetAllFanStatesAsync"/> should return exactly <c>fanCount</c>
-    /// <see cref="UglyClient.Models.FanDTO"/> items when all requests succeed.
-    /// </summary>
-    [Fact]
-    public async Task GetAllFanStatesAsync_AllSucceed_ReturnsCorrectCount()
-    {
-        // Arrange — same JSON returned for every fan
-        const string json = """{"Id":1,"IsOn":true}""";
-        var handler = CreateHandler(HttpStatusCode.OK, json);
-        var service = new FanService(BuildClient(handler), fanCount: 3);
-
-        // Act
-        var fans = await service.GetAllFanStatesAsync();
-
-        // Assert
-        Assert.Equal(3, fans.Count());
-    }
-
-    /// <summary>
-    /// When any individual fan GET fails, <see cref="FanService.GetAllFanStatesAsync"/>
-    /// must propagate the exception.
-    /// </summary>
-    [Fact]
-    public async Task GetAllFanStatesAsync_OneFails_ThrowsException()
-    {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.NotFound, string.Empty);
-        var service = new FanService(BuildClient(handler), fanCount: 2);
-
-        // Act &amp; Assert
-        await Assert.ThrowsAsync<Exception>(() => service.GetAllFanStatesAsync());
+        Assert.Equal(2, fans.Count);
+        Assert.Equal(1, fans[0].Id);
+        Assert.Equal(2, fans[1].Id);
     }
 }

--- a/UglyClient.Tests/Services/HeaterServiceTests.cs
+++ b/UglyClient.Tests/Services/HeaterServiceTests.cs
@@ -1,305 +1,111 @@
-using System.Net;
-using System.Text;
 using Moq;
-using Moq.Protected;
 using UglyClient.Services;
-using Xunit;
 
 namespace UglyClient.Tests.Services;
 
 /// <summary>
 /// Unit tests for <see cref="HeaterService"/>.
-/// Verifies that the service sends correctly structured HTTP requests and correctly
-/// parses responses or throws descriptive exceptions on failure.
 /// </summary>
 public class HeaterServiceTests
 {
-    // ── helpers ────────────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Builds an <see cref="HttpClient"/> whose transport is backed by the supplied mock
-    /// handler, with a predictable base address for URL assertions.
-    /// </summary>
-    /// <param name="handlerMock">The mocked <see cref="HttpMessageHandler"/>.</param>
-    /// <returns>An <see cref="HttpClient"/> wired to the mock handler.</returns>
-    private static HttpClient BuildClient(Mock<HttpMessageHandler> handlerMock)
-        => new HttpClient(handlerMock.Object)
-        {
-            BaseAddress = new Uri("http://test-server/")
-        };
-
-    /// <summary>
-    /// Creates a mock handler that always returns the given status code and body,
-    /// regardless of the request URI or method.
-    /// </summary>
-    /// <param name="statusCode">HTTP status code to return.</param>
-    /// <param name="responseBody">Response body text to return.</param>
-    /// <returns>A configured <see cref="Mock{HttpMessageHandler}"/>.</returns>
-    private static Mock<HttpMessageHandler> CreateHandler(HttpStatusCode statusCode, string responseBody)
-    {
-        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
-        mock.Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = statusCode,
-                Content = new StringContent(responseBody, Encoding.UTF8, "application/json")
-            });
-        return mock;
-    }
-
-    // ── Constructor ────────────────────────────────────────────────────────────
-
-    /// <summary>
-    /// Passing a null <see cref="HttpClient"/> should throw <see cref="ArgumentNullException"/>.
-    /// </summary>
     [Fact]
-    public void Constructor_NullClient_ThrowsArgumentNullException()
+    public void Constructor_NullHttpService_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() => new HeaterService(null!));
     }
 
-    /// <summary>
-    /// Passing a heater count of zero should throw <see cref="ArgumentOutOfRangeException"/>.
-    /// </summary>
     [Fact]
     public void Constructor_ZeroHeaterCount_ThrowsArgumentOutOfRangeException()
     {
-        var client = BuildClient(CreateHandler(HttpStatusCode.OK, string.Empty));
-        Assert.Throws<ArgumentOutOfRangeException>(() => new HeaterService(client, 0));
+        var httpService = new Mock<IHttpService>();
+        Assert.Throws<ArgumentOutOfRangeException>(() => new HeaterService(httpService.Object, 0));
     }
 
-    // ── SetHeaterLevelAsync ────────────────────────────────────────────────────
-
-    /// <summary>
-    /// When the API returns 200 OK, <see cref="HeaterService.SetHeaterLevelAsync"/> should
-    /// complete without throwing.
-    /// </summary>
     [Fact]
-    public async Task SetHeaterLevelAsync_SuccessResponse_DoesNotThrow()
+    public async Task SetHeaterLevelAsync_CallsExpectedEndpoint()
     {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.OK, string.Empty);
-        var service = new HeaterService(BuildClient(handler));
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService.Setup(service => service.PostAsync("api/heat/2", "5")).ReturnsAsync(string.Empty);
+        var heaterService = new HeaterService(httpService.Object);
 
-        // Act &amp; Assert — no exception expected
-        await service.SetHeaterLevelAsync(1, 3);
+        await heaterService.SetHeaterLevelAsync(2, 5);
+
+        httpService.VerifyAll();
     }
 
-    /// <summary>
-    /// <see cref="HeaterService.SetHeaterLevelAsync"/> must POST the integer level as a
-    /// string to <c>api/heat/{heaterId}</c>.
-    /// </summary>
     [Fact]
-    public async Task SetHeaterLevelAsync_PostsCorrectEndpointAndBody()
+    public async Task SetHeaterLevelAsync_WhenHttpFails_ThrowsDeviceServiceException()
     {
-        // Arrange
-        HttpRequestMessage? captured = null;
-        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
-        mock.Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
-            .ReturnsAsync(new HttpResponseMessage { StatusCode = HttpStatusCode.OK });
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService
+            .Setup(service => service.PostAsync("api/heat/1", "3"))
+            .ThrowsAsync(new DeviceServiceException("The simulation service is unavailable right now."));
+        var heaterService = new HeaterService(httpService.Object);
 
-        var service = new HeaterService(BuildClient(mock));
+        var exception = await Assert.ThrowsAsync<DeviceServiceException>(() => heaterService.SetHeaterLevelAsync(1, 3));
 
-        // Act
-        await service.SetHeaterLevelAsync(2, 5);
-
-        // Assert
-        Assert.NotNull(captured);
-        Assert.Equal(HttpMethod.Post, captured!.Method);
-        Assert.EndsWith("api/heat/2", captured.RequestUri!.ToString());
-        var body = await captured.Content!.ReadAsStringAsync();
-        Assert.Equal("5", body);
+        Assert.True(exception.Message.Contains("heater 1", StringComparison.OrdinalIgnoreCase));
     }
 
-    /// <summary>
-    /// When the API returns a non-success status code, <see cref="HeaterService.SetHeaterLevelAsync"/>
-    /// must throw an <see cref="Exception"/> that mentions the heater ID.
-    /// </summary>
-    [Fact]
-    public async Task SetHeaterLevelAsync_HttpFailure_ThrowsExceptionWithHeaterId()
-    {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.ServiceUnavailable, string.Empty);
-        var service = new HeaterService(BuildClient(handler));
-
-        // Act &amp; Assert
-        var ex = await Assert.ThrowsAsync<Exception>(() => service.SetHeaterLevelAsync(1, 3));
-        Assert.Contains("1", ex.Message);
-    }
-
-    // ── GetHeaterLevelAsync ────────────────────────────────────────────────────
-
-    /// <summary>
-    /// When the API returns a valid integer string body, <see cref="HeaterService.GetHeaterLevelAsync"/>
-    /// should parse and return the correct integer value.
-    /// </summary>
     [Fact]
     public async Task GetHeaterLevelAsync_ValidIntegerResponse_ReturnsLevel()
     {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.OK, "4");
-        var service = new HeaterService(BuildClient(handler));
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService.Setup(service => service.GetAsync("api/heat/3/level")).ReturnsAsync("4");
+        var heaterService = new HeaterService(httpService.Object);
 
-        // Act
-        var level = await service.GetHeaterLevelAsync(1);
+        var level = await heaterService.GetHeaterLevelAsync(3);
 
-        // Assert
         Assert.Equal(4, level);
     }
 
-    /// <summary>
-    /// <see cref="HeaterService.GetHeaterLevelAsync"/> should GET from <c>api/heat/{heaterId}/level</c>.
-    /// </summary>
     [Fact]
-    public async Task GetHeaterLevelAsync_CallsCorrectEndpoint()
+    public async Task GetHeaterLevelAsync_WhenHttpFails_ThrowsDeviceServiceException()
     {
-        // Arrange
-        HttpRequestMessage? captured = null;
-        var mock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
-        mock.Protected()
-            .Setup<Task<HttpResponseMessage>>(
-                "SendAsync",
-                ItExpr.IsAny<HttpRequestMessage>(),
-                ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
-            .ReturnsAsync(new HttpResponseMessage
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("2", Encoding.UTF8, "application/json")
-            });
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService
+            .Setup(service => service.GetAsync("api/heat/2/level"))
+            .ThrowsAsync(new DeviceServiceException("The simulation service is unavailable right now."));
+        var heaterService = new HeaterService(httpService.Object);
 
-        var service = new HeaterService(BuildClient(mock));
+        var exception = await Assert.ThrowsAsync<DeviceServiceException>(() => heaterService.GetHeaterLevelAsync(2));
 
-        // Act
-        await service.GetHeaterLevelAsync(3);
-
-        // Assert
-        Assert.Equal(HttpMethod.Get, captured!.Method);
-        Assert.EndsWith("api/heat/3/level", captured.RequestUri!.ToString());
+        Assert.True(exception.Message.Contains("heater 2", StringComparison.OrdinalIgnoreCase));
     }
 
-    /// <summary>
-    /// When the API returns a non-success status code, <see cref="HeaterService.GetHeaterLevelAsync"/>
-    /// must throw an <see cref="Exception"/> that mentions the heater ID.
-    /// </summary>
     [Fact]
-    public async Task GetHeaterLevelAsync_HttpFailure_ThrowsExceptionWithHeaterId()
+    public async Task GetHeaterLevelAsync_WhenResponseIsInvalid_ThrowsDeviceServiceException()
     {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.NotFound, string.Empty);
-        var service = new HeaterService(BuildClient(handler));
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService.Setup(service => service.GetAsync("api/heat/1/level")).ReturnsAsync("not-a-number");
+        var heaterService = new HeaterService(httpService.Object);
 
-        // Act &amp; Assert
-        var ex = await Assert.ThrowsAsync<Exception>(() => service.GetHeaterLevelAsync(2));
-        Assert.Contains("2", ex.Message);
+        await Assert.ThrowsAsync<DeviceServiceException>(() => heaterService.GetHeaterLevelAsync(1));
     }
 
-    /// <summary>
-    /// When the API returns a body that cannot be parsed as an integer,
-    /// <see cref="HeaterService.GetHeaterLevelAsync"/> must throw an <see cref="Exception"/>.
-    /// </summary>
     [Fact]
-    public async Task GetHeaterLevelAsync_NonIntegerResponse_ThrowsException()
+    public async Task SetAllHeatersAsync_CallsEachHeaterEndpoint()
     {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.OK, "not-a-number");
-        var service = new HeaterService(BuildClient(handler));
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService.Setup(service => service.PostAsync("api/heat/1", "0")).ReturnsAsync(string.Empty);
+        httpService.Setup(service => service.PostAsync("api/heat/2", "0")).ReturnsAsync(string.Empty);
+        var heaterService = new HeaterService(httpService.Object, heaterCount: 2);
 
-        // Act &amp; Assert
-        await Assert.ThrowsAsync<Exception>(() => service.GetHeaterLevelAsync(1));
+        await heaterService.SetAllHeatersAsync(0);
+
+        httpService.VerifyAll();
     }
 
-    // ── SetAllHeatersAsync ─────────────────────────────────────────────────────
-
-    /// <summary>
-    /// <see cref="HeaterService.SetAllHeatersAsync"/> must issue one POST per heater
-    /// (heaterCount = 2 here), all returning 200, without throwing.
-    /// </summary>
     [Fact]
-    public async Task SetAllHeatersAsync_AllSucceed_DoesNotThrow()
+    public async Task GetAllHeaterLevelsAsync_ReturnsLevelForEachHeater()
     {
-        // Arrange — handler always returns 200; heaterCount = 2 means exactly 2 POST calls
-        var handler = CreateHandler(HttpStatusCode.OK, string.Empty);
-        var service = new HeaterService(BuildClient(handler), heaterCount: 2);
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService.Setup(service => service.GetAsync("api/heat/1/level")).ReturnsAsync("2");
+        httpService.Setup(service => service.GetAsync("api/heat/2/level")).ReturnsAsync("5");
+        var heaterService = new HeaterService(httpService.Object, heaterCount: 2);
 
-        // Act &amp; Assert
-        await service.SetAllHeatersAsync(3);
-    }
+        var levels = (await heaterService.GetAllHeaterLevelsAsync()).ToList();
 
-    /// <summary>
-    /// When any heater POST fails, <see cref="HeaterService.SetAllHeatersAsync"/> must
-    /// propagate the exception from <see cref="HeaterService.SetHeaterLevelAsync"/>.
-    /// </summary>
-    [Fact]
-    public async Task SetAllHeatersAsync_OneFails_ThrowsException()
-    {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.InternalServerError, string.Empty);
-        var service = new HeaterService(BuildClient(handler), heaterCount: 3);
-
-        // Act &amp; Assert
-        await Assert.ThrowsAsync<Exception>(() => service.SetAllHeatersAsync(0));
-    }
-
-    // ── GetAllHeaterLevelsAsync ────────────────────────────────────────────────
-
-    /// <summary>
-    /// <see cref="HeaterService.GetAllHeaterLevelsAsync"/> should return exactly
-    /// <c>heaterCount</c> integer values when all requests succeed.
-    /// </summary>
-    [Fact]
-    public async Task GetAllHeaterLevelsAsync_AllSucceed_ReturnsCorrectCount()
-    {
-        // Arrange — same level returned for every heater
-        var handler = CreateHandler(HttpStatusCode.OK, "2");
-        var service = new HeaterService(BuildClient(handler), heaterCount: 3);
-
-        // Act
-        var levels = await service.GetAllHeaterLevelsAsync();
-
-        // Assert
-        Assert.Equal(3, levels.Count());
-    }
-
-    /// <summary>
-    /// Each item returned by <see cref="HeaterService.GetAllHeaterLevelsAsync"/> should
-    /// equal the parsed integer from the API response body.
-    /// </summary>
-    [Fact]
-    public async Task GetAllHeaterLevelsAsync_AllSucceed_ReturnsCorrectValues()
-    {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.OK, "5");
-        var service = new HeaterService(BuildClient(handler), heaterCount: 2);
-
-        // Act
-        var levels = await service.GetAllHeaterLevelsAsync();
-
-        // Assert — every heater should report level 5
-        Assert.All(levels, l => Assert.Equal(5, l));
-    }
-
-    /// <summary>
-    /// When any individual heater GET fails, <see cref="HeaterService.GetAllHeaterLevelsAsync"/>
-    /// must propagate the exception.
-    /// </summary>
-    [Fact]
-    public async Task GetAllHeaterLevelsAsync_OneFails_ThrowsException()
-    {
-        // Arrange
-        var handler = CreateHandler(HttpStatusCode.NotFound, string.Empty);
-        var service = new HeaterService(BuildClient(handler), heaterCount: 2);
-
-        // Act &amp; Assert
-        await Assert.ThrowsAsync<Exception>(() => service.GetAllHeaterLevelsAsync());
+        Assert.Equal([2, 5], levels);
     }
 }

--- a/UglyClient.Tests/Services/HttpServiceTests.cs
+++ b/UglyClient.Tests/Services/HttpServiceTests.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using Moq;
+using Moq.Protected;
+using UglyClient.Services;
+
+namespace UglyClient.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="HttpService"/>.
+/// </summary>
+public class HttpServiceTests
+{
+    [Fact]
+    public async Task GetAsync_SuccessResponse_ReturnsBody()
+    {
+        var handler = CreateHandler(new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("ok")
+        });
+        var httpService = new HttpService(CreateClient(handler));
+
+        var result = await httpService.GetAsync("api/test");
+
+        Assert.Equal("ok", result);
+    }
+
+    [Fact]
+    public async Task GetAsync_NonSuccessStatus_ThrowsDeviceServiceException()
+    {
+        var handler = CreateHandler(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+        var httpService = new HttpService(CreateClient(handler));
+
+        await Assert.ThrowsAsync<DeviceServiceException>(() => httpService.GetAsync("api/test"));
+    }
+
+    [Fact]
+    public async Task PostAsync_TransportFailure_ThrowsDeviceServiceException()
+    {
+        var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("network error"));
+        var httpService = new HttpService(CreateClient(handler));
+
+        await Assert.ThrowsAsync<DeviceServiceException>(() => httpService.PostAsync("api/test", "{}"));
+    }
+
+    private static HttpClient CreateClient(Mock<HttpMessageHandler> handler)
+    {
+        return new HttpClient(handler.Object)
+        {
+            BaseAddress = new Uri("http://test-server/")
+        };
+    }
+
+    private static Mock<HttpMessageHandler> CreateHandler(HttpResponseMessage response)
+    {
+        var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(response);
+        return handler;
+    }
+}

--- a/UglyClient.Tests/Services/SensorServiceTests.cs
+++ b/UglyClient.Tests/Services/SensorServiceTests.cs
@@ -6,120 +6,87 @@ namespace UglyClient.Tests.Services;
 
 /// <summary>
 /// Unit tests for <see cref="SensorService"/>.
-/// Verifies adapter delegation, average calculation, guard clauses, and error propagation.
 /// </summary>
 public class SensorServiceTests
 {
-    /// <summary>
-    /// Passing a null sensor collection should throw <see cref="ArgumentNullException"/>.
-    /// </summary>
     [Fact]
     public void Constructor_NullSensors_ThrowsArgumentNullException()
     {
         Assert.Throws<ArgumentNullException>(() => new SensorService(null!));
     }
 
-    /// <summary>
-    /// Passing an empty sensor collection should throw <see cref="ArgumentException"/>.
-    /// </summary>
     [Fact]
     public void Constructor_EmptySensors_ThrowsArgumentException()
     {
         Assert.Throws<ArgumentException>(() => new SensorService([]));
     }
 
-    /// <summary>
-    /// Duplicate sensor identifiers should be rejected because the service must map each ID
-    /// to exactly one adapter.
-    /// </summary>
     [Fact]
     public void Constructor_DuplicateSensorIds_ThrowsArgumentException()
     {
         var sensor1 = CreateSensorMock(1, 20.0);
         var duplicateSensor1 = CreateSensorMock(1, 22.0);
 
-        var ex = Assert.Throws<ArgumentException>(() => new SensorService([sensor1.Object, duplicateSensor1.Object]));
-
-        Assert.Contains("Duplicate sensor ID", ex.Message);
+        Assert.Throws<ArgumentException>(() => new SensorService([sensor1.Object, duplicateSensor1.Object]));
     }
 
-    /// <summary>
-    /// <see cref="SensorService.GetTemperatureAsync"/> should delegate to the adapter matching
-    /// the requested sensor identifier.
-    /// </summary>
     [Fact]
     public async Task GetTemperatureAsync_ValidSensorId_DelegatesToMatchingAdapter()
     {
         var sensor1 = CreateSensorMock(1, 20.0);
         var sensor2 = CreateSensorMock(2, 24.5);
-        var service = new SensorService([sensor1.Object, sensor2.Object]);
+        var sensorService = new SensorService([sensor1.Object, sensor2.Object]);
 
-        var result = await service.GetTemperatureAsync(2);
+        var result = await sensorService.GetTemperatureAsync(2);
 
         Assert.Equal(24.5, result, precision: 5);
-        sensor1.Verify(s => s.GetTemperatureAsync(), Times.Never);
-        sensor2.Verify(s => s.GetTemperatureAsync(), Times.Once);
+        sensor1.Verify(sensor => sensor.GetTemperatureAsync(), Times.Never);
+        sensor2.Verify(sensor => sensor.GetTemperatureAsync(), Times.Once);
     }
 
-    /// <summary>
-    /// Requesting a sensor ID that is not present should fail clearly.
-    /// </summary>
     [Fact]
-    public async Task GetTemperatureAsync_InvalidSensorId_ThrowsKeyNotFoundException()
+    public async Task GetTemperatureAsync_InvalidSensorId_ThrowsDeviceServiceException()
     {
         var sensor1 = CreateSensorMock(1, 20.0);
-        var service = new SensorService([sensor1.Object]);
+        var sensorService = new SensorService([sensor1.Object]);
 
-        var ex = await Assert.ThrowsAsync<KeyNotFoundException>(() => service.GetTemperatureAsync(3));
+        var exception = await Assert.ThrowsAsync<DeviceServiceException>(() => sensorService.GetTemperatureAsync(3));
 
-        Assert.Contains("Sensor 3", ex.Message);
+        Assert.True(exception.Message.Contains("Sensor 3", StringComparison.OrdinalIgnoreCase));
     }
 
-    /// <summary>
-    /// <see cref="SensorService.GetAverageTemperatureAsync"/> should average all managed sensors.
-    /// </summary>
     [Fact]
-    public async Task GetAverageTemperatureAsync_AllSensorsPresent_ReturnsAverage()
+    public async Task GetAverageTemperatureAsync_ReturnsAverage()
     {
         var sensor1 = CreateSensorMock(1, 18.0);
         var sensor2 = CreateSensorMock(2, 21.0);
         var sensor3 = CreateSensorMock(3, 24.0);
-        var service = new SensorService([sensor1.Object, sensor2.Object, sensor3.Object]);
+        var sensorService = new SensorService([sensor1.Object, sensor2.Object, sensor3.Object]);
 
-        var result = await service.GetAverageTemperatureAsync();
+        var result = await sensorService.GetAverageTemperatureAsync();
 
         Assert.Equal(21.0, result, precision: 5);
     }
 
-    /// <summary>
-    /// When an adapter throws while calculating the average, the exception should propagate.
-    /// </summary>
     [Fact]
-    public async Task GetAverageTemperatureAsync_AdapterThrows_PropagatesException()
+    public async Task GetAverageTemperatureAsync_WhenAdapterFails_PropagatesDeviceServiceException()
     {
         var sensor1 = CreateSensorMock(1, 18.0);
         var sensor2 = new Mock<ISensor>();
-        sensor2.SetupGet(s => s.SensorId).Returns(2);
-        sensor2.Setup(s => s.GetTemperatureAsync()).ThrowsAsync(new Exception("Sensor 2 failed."));
+        sensor2.SetupGet(sensor => sensor.SensorId).Returns(2);
+        sensor2
+            .Setup(sensor => sensor.GetTemperatureAsync())
+            .ThrowsAsync(new DeviceServiceException("Unable to load sensor 2 right now."));
+        var sensorService = new SensorService([sensor1.Object, sensor2.Object]);
 
-        var service = new SensorService([sensor1.Object, sensor2.Object]);
-
-        var ex = await Assert.ThrowsAsync<Exception>(() => service.GetAverageTemperatureAsync());
-
-        Assert.Contains("Sensor 2 failed", ex.Message);
+        await Assert.ThrowsAsync<DeviceServiceException>(() => sensorService.GetAverageTemperatureAsync());
     }
 
-    /// <summary>
-    /// Builds a mock sensor adapter with a fixed identifier and temperature response.
-    /// </summary>
-    /// <param name="sensorId">The identifier exposed by the adapter.</param>
-    /// <param name="temperature">The temperature returned by <see cref="ISensor.GetTemperatureAsync"/>.</param>
-    /// <returns>A configured <see cref="Mock{ISensor}"/>.</returns>
     private static Mock<ISensor> CreateSensorMock(int sensorId, double temperature)
     {
         var sensor = new Mock<ISensor>();
-        sensor.SetupGet(s => s.SensorId).Returns(sensorId);
-        sensor.Setup(s => s.GetTemperatureAsync()).ReturnsAsync(temperature);
+        sensor.SetupGet(adapter => adapter.SensorId).Returns(sensorId);
+        sensor.Setup(adapter => adapter.GetTemperatureAsync()).ReturnsAsync(temperature);
         return sensor;
     }
 }

--- a/UglyClient.Tests/Services/SimulationServiceTests.cs
+++ b/UglyClient.Tests/Services/SimulationServiceTests.cs
@@ -1,0 +1,40 @@
+using Moq;
+using UglyClient.Services;
+
+namespace UglyClient.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="SimulationService"/>.
+/// </summary>
+public class SimulationServiceTests
+{
+    [Fact]
+    public void Constructor_NullHttpService_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new SimulationService(null!));
+    }
+
+    [Fact]
+    public async Task ResetAsync_CallsResetEndpoint()
+    {
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService.Setup(service => service.PostAsync("api/Envo/reset", string.Empty)).ReturnsAsync(string.Empty);
+        var simulationService = new SimulationService(httpService.Object);
+
+        await simulationService.ResetAsync();
+
+        httpService.VerifyAll();
+    }
+
+    [Fact]
+    public async Task ResetAsync_WhenHttpFails_ThrowsDeviceServiceException()
+    {
+        var httpService = new Mock<IHttpService>(MockBehavior.Strict);
+        httpService
+            .Setup(service => service.PostAsync("api/Envo/reset", string.Empty))
+            .ThrowsAsync(new DeviceServiceException("The simulation service is unavailable right now."));
+        var simulationService = new SimulationService(httpService.Object);
+
+        await Assert.ThrowsAsync<DeviceServiceException>(() => simulationService.ResetAsync());
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a shared DeviceServiceException for client service failures
- move HTTP failure handling behind HttpService, service facades, sensor adapters, and a new SimulationService
- replace broad UI catches in Program.cs with friendly DeviceServiceException handling and add failure-path tests

## Testing
- dotnet format UglyClient.sln
- dotnet test UglyClient.sln

Closes #12