### PR TITLE
feat: implement temperature control strategies (#15)

### DIFF
--- a/Interfaces/ITemperatureControlStrategy.cs
+++ b/Interfaces/ITemperatureControlStrategy.cs
@@ -1,0 +1,21 @@
+namespace UglyClient.Interfaces;
+
+/// <summary>
+/// Defines the contract for a temperature-control algorithm used during a simulation phase.
+/// </summary>
+public interface ITemperatureControlStrategy
+{
+    /// <summary>
+    /// Executes the temperature-control algorithm for the supplied phase settings.
+    /// </summary>
+    /// <param name="currentTemperature">The temperature observed at the start of the phase.</param>
+    /// <param name="targetTemperature">The desired target temperature for the phase.</param>
+    /// <param name="durationSeconds">The maximum number of one-second iterations to perform.</param>
+    /// <param name="cancellationToken">The token used to cancel the phase while it is running.</param>
+    /// <returns>The last temperature observed before the phase completed.</returns>
+    Task<double> ExecuteAsync(
+        double currentTemperature,
+        double targetTemperature,
+        int durationSeconds,
+        CancellationToken cancellationToken = default);
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,13 +1,19 @@
-﻿using System;
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 using UglyClient.Adapters;
 using UglyClient.Config;
 using UglyClient.Interfaces;
 using UglyClient.Services;
+using UglyClient.Strategies;
 
 class Program
 {
+    /// <summary>
+    /// The tolerance used to treat two temperature readings as effectively equal.
+    /// </summary>
+    private const double TemperatureTolerance = 0.1;
+
     static async Task Main(string[] args)
     {
         var config = new SimulationConfig(
@@ -39,6 +45,9 @@ class Program
 
         // Facade / Service layer: HeaterService encapsulates all heater-related HTTP calls.
         IHeaterService heaterService = new HeaterService(client, config.HeaterCount);
+        ITemperatureControlStrategy heatUpStrategy = new HeatUpStrategy(heaterService, fanService, sensorService);
+        ITemperatureControlStrategy coolDownStrategy = new CoolDownStrategy(heaterService, fanService, sensorService);
+        ITemperatureControlStrategy holdStrategy = new HoldStrategy(heaterService, fanService, sensorService);
 
         while (true)
         {
@@ -162,25 +171,8 @@ class Program
                     }
                     break;
                 case "5":
-                    //await RunTemperatureControlLoop(client);
-                    Console.WriteLine("Starting temperature control algorithm...");
-                    Console.Write("Provide a final Temp Value: ");
-                    double currentTemperature = await sensorService.GetAverageTemperatureAsync();
-                    while (true)
-                    {
-                        // Phase 1: Gradually increase to 20°C over 30 seconds
-                        currentTemperature = await AdjustTemperature(heaterService, fanService, sensorService, currentTemperature, 20.0, 30);
-
-                        // Phase 2: Rapidly cool to 16°C
-                        currentTemperature = await AdjustTemperature(heaterService, fanService, sensorService, currentTemperature, 16.0, 10);
-
-                        // Phase 3: Hold at 16°C for 10 seconds
-                        currentTemperature = await HoldTemperature(heaterService, fanService, sensorService, currentTemperature, 16.0, 10);
-
-                        // Phase 4: Gradually return to 18°C and maintain
-                        currentTemperature = await AdjustTemperature(heaterService, fanService, sensorService, currentTemperature, 18.0, 20);
-                        currentTemperature = await HoldTemperature(heaterService, fanService, sensorService, currentTemperature, 18.0, int.MaxValue); // Maintain until exit
-                    }
+                    await RunTemperatureControlLoop(sensorService, heatUpStrategy, coolDownStrategy, holdStrategy);
+                    break;
                 case "6":
                     // await Reset(client);
                     Console.WriteLine("Resetting client state...");
@@ -250,10 +242,15 @@ class Program
     /// <summary>
     /// Runs the interactive temperature-control loop using the heater, fan, and sensor facades.
     /// </summary>
-    /// <param name="heaterService">The heater facade used to control all heaters.</param>
-    /// <param name="fanService">The fan facade used to control all fans.</param>
     /// <param name="sensorService">The sensor facade used to read current temperatures.</param>
-    static async Task RunTemperatureControlLoop(IHeaterService heaterService, IFanService fanService, ISensorService sensorService)
+    /// <param name="heatUpStrategy">The strategy used when the target temperature is above the current temperature.</param>
+    /// <param name="coolDownStrategy">The strategy used when the target temperature is below the current temperature.</param>
+    /// <param name="holdStrategy">The strategy used to maintain a target temperature.</param>
+    static async Task RunTemperatureControlLoop(
+        ISensorService sensorService,
+        ITemperatureControlStrategy heatUpStrategy,
+        ITemperatureControlStrategy coolDownStrategy,
+        ITemperatureControlStrategy holdStrategy)
     {
         Console.WriteLine("Starting temperature control algorithm...");
 
@@ -270,99 +267,52 @@ class Program
         while (true)
         {
             // Phase 1: Gradually increase to 20°C over 30 seconds
-            currentTemperature = await AdjustTemperature(heaterService, fanService, sensorService, currentTemperature, 20.0, 30);
+            Console.WriteLine("Heating to 20.0°C over 30 seconds...");
+            currentTemperature = await ExecuteAdjustmentPhaseAsync(currentTemperature, 20.0, 30, heatUpStrategy, coolDownStrategy);
+            Console.WriteLine($"Current Temperature: {currentTemperature:F1}°C");
 
             // Phase 2: Rapidly cool to 16°C
-            currentTemperature = await AdjustTemperature(heaterService, fanService, sensorService, currentTemperature, 16.0, 10);
+            Console.WriteLine("Cooling to 16.0°C over 10 seconds...");
+            currentTemperature = await ExecuteAdjustmentPhaseAsync(currentTemperature, 16.0, 10, heatUpStrategy, coolDownStrategy);
+            Console.WriteLine($"Current Temperature: {currentTemperature:F1}°C");
 
             // Phase 3: Hold at 16°C for 10 seconds
-            currentTemperature = await HoldTemperature(heaterService, fanService, sensorService, currentTemperature, 16.0, 10);
+            Console.WriteLine("Holding temperature at 16.0°C for 10 seconds...");
+            currentTemperature = await holdStrategy.ExecuteAsync(currentTemperature, 16.0, 10);
+            Console.WriteLine($"Current Temperature: {currentTemperature:F1}°C");
 
             // Phase 4: Gradually adjust to the user-defined target temperature and maintain
-            currentTemperature = await AdjustTemperature(heaterService, fanService, sensorService, currentTemperature, finalTargetTemperature, 20);
-            currentTemperature = await HoldTemperature(heaterService, fanService, sensorService, currentTemperature, finalTargetTemperature, int.MaxValue); // Maintain until exit
+            Console.WriteLine($"Adjusting temperature to {finalTargetTemperature:F1}°C over 20 seconds...");
+            currentTemperature = await ExecuteAdjustmentPhaseAsync(currentTemperature, finalTargetTemperature, 20, heatUpStrategy, coolDownStrategy);
+            Console.WriteLine($"Current Temperature: {currentTemperature:F1}°C");
+            Console.WriteLine($"Holding temperature at {finalTargetTemperature:F1}°C until exit...");
+            currentTemperature = await holdStrategy.ExecuteAsync(currentTemperature, finalTargetTemperature, int.MaxValue);
         }
     }
 
     /// <summary>
-    /// Gradually moves the environment temperature toward a target over a bounded duration.
+    /// Executes the appropriate adjustment strategy for the requested target temperature.
     /// </summary>
-    /// <param name="heaterService">The heater facade used to raise temperature.</param>
-    /// <param name="fanService">The fan facade used to lower temperature.</param>
-    /// <param name="sensorService">The sensor facade used to read average temperature.</param>
     /// <param name="currentTemperature">The current average temperature before the adjustment loop starts.</param>
     /// <param name="targetTemperature">The target average temperature.</param>
     /// <param name="durationSeconds">The maximum number of one-second adjustment iterations to run.</param>
-    /// <returns>The final average temperature observed when the loop ends.</returns>
-    static async Task<double> AdjustTemperature(IHeaterService heaterService, IFanService fanService, ISensorService sensorService, double currentTemperature, double targetTemperature, int durationSeconds)
+    /// <param name="heatUpStrategy">The strategy used when heating is required.</param>
+    /// <param name="coolDownStrategy">The strategy used when cooling is required.</param>
+    /// <returns>The final average temperature observed when the phase ends.</returns>
+    static async Task<double> ExecuteAdjustmentPhaseAsync(
+        double currentTemperature,
+        double targetTemperature,
+        int durationSeconds,
+        ITemperatureControlStrategy heatUpStrategy,
+        ITemperatureControlStrategy coolDownStrategy)
     {
-        Console.WriteLine($"Adjusting temperature to {targetTemperature}°C over {durationSeconds} seconds...");
-        int intervalMs = 1000; // 1-second intervals
-        int iterations = durationSeconds;
-
-        for (int i = 0; i < iterations; i++)
+        if (Math.Abs(currentTemperature - targetTemperature) <= TemperatureTolerance)
         {
-            if (Math.Abs(currentTemperature - targetTemperature) <= 0.1) break;
-
-            if (currentTemperature < targetTemperature)
-            {
-                // Turn on heaters and reduce fan activity
-                await heaterService.SetAllHeatersAsync(3); // Set heaters to level 3
-                await fanService.SetAllFansAsync(false);    // Turn off fans
-            }
-            else
-            {
-                // Turn off heaters and increase fan activity
-                await heaterService.SetAllHeatersAsync(0); // Turn off heaters
-                await fanService.SetAllFansAsync(true);     // Turn on fans
-            }
-
-            // Wait for a second and fetch the updated temperature
-            await Task.Delay(intervalMs);
-            currentTemperature = await sensorService.GetAverageTemperatureAsync();
-            Console.WriteLine($"Current Temperature: {currentTemperature:F1}°C");
+            return currentTemperature;
         }
 
-        return currentTemperature;
-    }
-
-    /// <summary>
-    /// Attempts to maintain the environment near a target temperature for a duration.
-    /// </summary>
-    /// <param name="heaterService">The heater facade used to apply corrective heating.</param>
-    /// <param name="fanService">The fan facade used to apply corrective cooling.</param>
-    /// <param name="sensorService">The sensor facade used to read average temperature.</param>
-    /// <param name="currentTemperature">The current average temperature before the hold loop starts.</param>
-    /// <param name="targetTemperature">The target average temperature to maintain.</param>
-    /// <param name="durationSeconds">The number of one-second iterations to perform.</param>
-    /// <returns>The final average temperature observed when the hold loop ends.</returns>
-    static async Task<double> HoldTemperature(IHeaterService heaterService, IFanService fanService, ISensorService sensorService, double currentTemperature, double targetTemperature, int durationSeconds)
-    {
-        Console.WriteLine($"Holding temperature at {targetTemperature}°C for {durationSeconds} seconds...");
-        int intervalMs = 1000; // 1-second intervals
-
-        for (int i = 0; i < durationSeconds; i++)
-        {
-            if (currentTemperature < targetTemperature)
-            {
-                // Turn on heaters slightly and reduce fans
-                await heaterService.SetAllHeatersAsync(1); // Minimal heating
-                await fanService.SetAllFansAsync(false); // Reduce cooling
-            }
-            else if (currentTemperature > targetTemperature)
-            {
-                // Turn off heaters and increase fans
-                await heaterService.SetAllHeatersAsync(0); // Turn off heating
-                await fanService.SetAllFansAsync(true); // Activate cooling
-            }
-
-            // Wait for a second and fetch the updated temperature
-            await Task.Delay(intervalMs);
-            currentTemperature = await sensorService.GetAverageTemperatureAsync();
-            Console.WriteLine($"Current Temperature: {currentTemperature:F1}°C");
-        }
-
-        return currentTemperature;
+        var selectedStrategy = currentTemperature < targetTemperature ? heatUpStrategy : coolDownStrategy;
+        return await selectedStrategy.ExecuteAsync(currentTemperature, targetTemperature, durationSeconds);
     }
 
     /// <summary>

--- a/Strategies/CoolDownStrategy.cs
+++ b/Strategies/CoolDownStrategy.cs
@@ -1,0 +1,106 @@
+using UglyClient.Interfaces;
+using UglyClient.Services;
+
+namespace UglyClient.Strategies;
+
+/// <summary>
+/// Lowers the environment temperature by disabling heaters and enabling fans until the target is reached
+/// or the allotted duration expires.
+/// </summary>
+public class CoolDownStrategy : ITemperatureControlStrategy
+{
+    /// <summary>
+    /// The tolerance used to stop once the target temperature has effectively been reached.
+    /// </summary>
+    private const double TemperatureTolerance = 0.1;
+
+    /// <summary>
+    /// The delay between successive temperature polls.
+    /// </summary>
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// The heater facade used to stop heating during cool-down.
+    /// </summary>
+    private readonly IHeaterService _heaterService;
+
+    /// <summary>
+    /// The fan facade used to increase cooling.
+    /// </summary>
+    private readonly IFanService _fanService;
+
+    /// <summary>
+    /// The sensor facade used to poll the current average temperature.
+    /// </summary>
+    private readonly ISensorService _sensorService;
+
+    /// <summary>
+    /// The delay operation used between polls.
+    /// </summary>
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="CoolDownStrategy"/>.
+    /// </summary>
+    /// <param name="heaterService">The heater facade used to control all heaters.</param>
+    /// <param name="fanService">The fan facade used to control all fans.</param>
+    /// <param name="sensorService">The sensor facade used to read temperatures.</param>
+    /// <param name="delayAsync">The delay operation used between temperature polls.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="heaterService"/>, <paramref name="fanService"/>, or
+    /// <paramref name="sensorService"/> is <see langword="null"/>.
+    /// </exception>
+    public CoolDownStrategy(
+        IHeaterService heaterService,
+        IFanService fanService,
+        ISensorService sensorService,
+        Func<TimeSpan, CancellationToken, Task>? delayAsync = null)
+    {
+        _heaterService = heaterService ?? throw new ArgumentNullException(nameof(heaterService));
+        _fanService = fanService ?? throw new ArgumentNullException(nameof(fanService));
+        _sensorService = sensorService ?? throw new ArgumentNullException(nameof(sensorService));
+        _delayAsync = delayAsync ?? Task.Delay;
+    }
+
+    /// <inheritdoc />
+    public async Task<double> ExecuteAsync(
+        double currentTemperature,
+        double targetTemperature,
+        int durationSeconds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(durationSeconds);
+
+        for (int iteration = 0; iteration < durationSeconds; iteration++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (HasReachedTarget(currentTemperature, targetTemperature))
+            {
+                break;
+            }
+
+            await _heaterService.SetAllHeatersAsync(0);
+            await _fanService.SetAllFansAsync(true);
+            await _delayAsync(PollInterval, cancellationToken);
+            currentTemperature = await _sensorService.GetAverageTemperatureAsync();
+        }
+
+        return currentTemperature;
+    }
+
+    /// <summary>
+    /// Determines whether the cool-down phase can stop because the target has been reached.
+    /// </summary>
+    /// <param name="currentTemperature">The latest observed temperature.</param>
+    /// <param name="targetTemperature">The target temperature for the phase.</param>
+    /// <returns>
+    /// <see langword="true"/> when the temperature is within tolerance of the target or already below it;
+    /// otherwise <see langword="false"/>.
+    /// </returns>
+    private static bool HasReachedTarget(double currentTemperature, double targetTemperature)
+    {
+        return currentTemperature <= targetTemperature ||
+               Math.Abs(currentTemperature - targetTemperature) <= TemperatureTolerance;
+    }
+}

--- a/Strategies/HeatUpStrategy.cs
+++ b/Strategies/HeatUpStrategy.cs
@@ -1,0 +1,111 @@
+using UglyClient.Interfaces;
+using UglyClient.Services;
+
+namespace UglyClient.Strategies;
+
+/// <summary>
+/// Raises the environment temperature by enabling heaters and disabling fans until the target is reached
+/// or the allotted duration expires.
+/// </summary>
+public class HeatUpStrategy : ITemperatureControlStrategy
+{
+    /// <summary>
+    /// The heater level applied while heating the environment.
+    /// </summary>
+    private const int HeatingLevel = 3;
+
+    /// <summary>
+    /// The tolerance used to stop once the target temperature has effectively been reached.
+    /// </summary>
+    private const double TemperatureTolerance = 0.1;
+
+    /// <summary>
+    /// The delay between successive temperature polls.
+    /// </summary>
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// The heater facade used to apply heat.
+    /// </summary>
+    private readonly IHeaterService _heaterService;
+
+    /// <summary>
+    /// The fan facade used to reduce cooling while heating.
+    /// </summary>
+    private readonly IFanService _fanService;
+
+    /// <summary>
+    /// The sensor facade used to poll the current average temperature.
+    /// </summary>
+    private readonly ISensorService _sensorService;
+
+    /// <summary>
+    /// The delay operation used between polls.
+    /// </summary>
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="HeatUpStrategy"/>.
+    /// </summary>
+    /// <param name="heaterService">The heater facade used to control all heaters.</param>
+    /// <param name="fanService">The fan facade used to control all fans.</param>
+    /// <param name="sensorService">The sensor facade used to read temperatures.</param>
+    /// <param name="delayAsync">The delay operation used between temperature polls.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="heaterService"/>, <paramref name="fanService"/>, or
+    /// <paramref name="sensorService"/> is <see langword="null"/>.
+    /// </exception>
+    public HeatUpStrategy(
+        IHeaterService heaterService,
+        IFanService fanService,
+        ISensorService sensorService,
+        Func<TimeSpan, CancellationToken, Task>? delayAsync = null)
+    {
+        _heaterService = heaterService ?? throw new ArgumentNullException(nameof(heaterService));
+        _fanService = fanService ?? throw new ArgumentNullException(nameof(fanService));
+        _sensorService = sensorService ?? throw new ArgumentNullException(nameof(sensorService));
+        _delayAsync = delayAsync ?? Task.Delay;
+    }
+
+    /// <inheritdoc />
+    public async Task<double> ExecuteAsync(
+        double currentTemperature,
+        double targetTemperature,
+        int durationSeconds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(durationSeconds);
+
+        for (int iteration = 0; iteration < durationSeconds; iteration++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (HasReachedTarget(currentTemperature, targetTemperature))
+            {
+                break;
+            }
+
+            await _heaterService.SetAllHeatersAsync(HeatingLevel);
+            await _fanService.SetAllFansAsync(false);
+            await _delayAsync(PollInterval, cancellationToken);
+            currentTemperature = await _sensorService.GetAverageTemperatureAsync();
+        }
+
+        return currentTemperature;
+    }
+
+    /// <summary>
+    /// Determines whether the heat-up phase can stop because the target has been reached.
+    /// </summary>
+    /// <param name="currentTemperature">The latest observed temperature.</param>
+    /// <param name="targetTemperature">The target temperature for the phase.</param>
+    /// <returns>
+    /// <see langword="true"/> when the temperature is within tolerance of the target or already above it;
+    /// otherwise <see langword="false"/>.
+    /// </returns>
+    private static bool HasReachedTarget(double currentTemperature, double targetTemperature)
+    {
+        return currentTemperature >= targetTemperature ||
+               Math.Abs(currentTemperature - targetTemperature) <= TemperatureTolerance;
+    }
+}

--- a/Strategies/HoldStrategy.cs
+++ b/Strategies/HoldStrategy.cs
@@ -1,0 +1,95 @@
+using UglyClient.Interfaces;
+using UglyClient.Services;
+
+namespace UglyClient.Strategies;
+
+/// <summary>
+/// Maintains the environment temperature near a target by applying small corrective changes and
+/// polling the average temperature once per second.
+/// </summary>
+public class HoldStrategy : ITemperatureControlStrategy
+{
+    /// <summary>
+    /// The heater level applied while correcting a temperature that is below the target.
+    /// </summary>
+    private const int MinimalHeatingLevel = 1;
+
+    /// <summary>
+    /// The delay between successive temperature polls.
+    /// </summary>
+    private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// The heater facade used to apply corrective heating.
+    /// </summary>
+    private readonly IHeaterService _heaterService;
+
+    /// <summary>
+    /// The fan facade used to apply corrective cooling.
+    /// </summary>
+    private readonly IFanService _fanService;
+
+    /// <summary>
+    /// The sensor facade used to poll the current average temperature.
+    /// </summary>
+    private readonly ISensorService _sensorService;
+
+    /// <summary>
+    /// The delay operation used between polls.
+    /// </summary>
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="HoldStrategy"/>.
+    /// </summary>
+    /// <param name="heaterService">The heater facade used to control all heaters.</param>
+    /// <param name="fanService">The fan facade used to control all fans.</param>
+    /// <param name="sensorService">The sensor facade used to read temperatures.</param>
+    /// <param name="delayAsync">The delay operation used between temperature polls.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="heaterService"/>, <paramref name="fanService"/>, or
+    /// <paramref name="sensorService"/> is <see langword="null"/>.
+    /// </exception>
+    public HoldStrategy(
+        IHeaterService heaterService,
+        IFanService fanService,
+        ISensorService sensorService,
+        Func<TimeSpan, CancellationToken, Task>? delayAsync = null)
+    {
+        _heaterService = heaterService ?? throw new ArgumentNullException(nameof(heaterService));
+        _fanService = fanService ?? throw new ArgumentNullException(nameof(fanService));
+        _sensorService = sensorService ?? throw new ArgumentNullException(nameof(sensorService));
+        _delayAsync = delayAsync ?? Task.Delay;
+    }
+
+    /// <inheritdoc />
+    public async Task<double> ExecuteAsync(
+        double currentTemperature,
+        double targetTemperature,
+        int durationSeconds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(durationSeconds);
+
+        for (int iteration = 0; iteration < durationSeconds; iteration++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (currentTemperature < targetTemperature)
+            {
+                await _heaterService.SetAllHeatersAsync(MinimalHeatingLevel);
+                await _fanService.SetAllFansAsync(false);
+            }
+            else if (currentTemperature > targetTemperature)
+            {
+                await _heaterService.SetAllHeatersAsync(0);
+                await _fanService.SetAllFansAsync(true);
+            }
+
+            await _delayAsync(PollInterval, cancellationToken);
+            currentTemperature = await _sensorService.GetAverageTemperatureAsync();
+        }
+
+        return currentTemperature;
+    }
+}

--- a/UglyClient.Tests/Strategies/CoolDownStrategyTests.cs
+++ b/UglyClient.Tests/Strategies/CoolDownStrategyTests.cs
@@ -1,0 +1,57 @@
+using Moq;
+using UglyClient.Services;
+using UglyClient.Strategies;
+
+namespace UglyClient.Tests.Strategies;
+
+/// <summary>
+/// Unit tests for <see cref="CoolDownStrategy"/>.
+/// </summary>
+public class CoolDownStrategyTests
+{
+    [Fact]
+    public async Task ExecuteAsync_AboveTarget_CoolsUntilTargetIsReached()
+    {
+        var heaterService = new Mock<IHeaterService>(MockBehavior.Strict);
+        var fanService = new Mock<IFanService>(MockBehavior.Strict);
+        var sensorService = new Mock<ISensorService>(MockBehavior.Strict);
+
+        heaterService.Setup(service => service.SetAllHeatersAsync(0)).Returns(Task.CompletedTask).Verifiable();
+        fanService.Setup(service => service.SetAllFansAsync(true)).Returns(Task.CompletedTask).Verifiable();
+        sensorService.Setup(service => service.GetAverageTemperatureAsync()).ReturnsAsync(16.0).Verifiable();
+
+        var strategy = new CoolDownStrategy(
+            heaterService.Object,
+            fanService.Object,
+            sensorService.Object,
+            (_, _) => Task.CompletedTask);
+
+        var result = await strategy.ExecuteAsync(19.0, 16.0, 5);
+
+        Assert.Equal(16.0, result, precision: 5);
+        heaterService.Verify(service => service.SetAllHeatersAsync(0), Times.Once);
+        fanService.Verify(service => service.SetAllFansAsync(true), Times.Once);
+        sensorService.Verify(service => service.GetAverageTemperatureAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AlreadyBelowTarget_ReturnsWithoutChangingDevices()
+    {
+        var heaterService = new Mock<IHeaterService>(MockBehavior.Strict);
+        var fanService = new Mock<IFanService>(MockBehavior.Strict);
+        var sensorService = new Mock<ISensorService>(MockBehavior.Strict);
+
+        var strategy = new CoolDownStrategy(
+            heaterService.Object,
+            fanService.Object,
+            sensorService.Object,
+            (_, _) => Task.CompletedTask);
+
+        var result = await strategy.ExecuteAsync(15.9, 16.0, 5);
+
+        Assert.Equal(15.9, result, precision: 5);
+        heaterService.Verify(service => service.SetAllHeatersAsync(It.IsAny<int>()), Times.Never);
+        fanService.Verify(service => service.SetAllFansAsync(It.IsAny<bool>()), Times.Never);
+        sensorService.Verify(service => service.GetAverageTemperatureAsync(), Times.Never);
+    }
+}

--- a/UglyClient.Tests/Strategies/HeatUpStrategyTests.cs
+++ b/UglyClient.Tests/Strategies/HeatUpStrategyTests.cs
@@ -1,0 +1,57 @@
+using Moq;
+using UglyClient.Services;
+using UglyClient.Strategies;
+
+namespace UglyClient.Tests.Strategies;
+
+/// <summary>
+/// Unit tests for <see cref="HeatUpStrategy"/>.
+/// </summary>
+public class HeatUpStrategyTests
+{
+    [Fact]
+    public async Task ExecuteAsync_BelowTarget_HeatsUntilTargetIsReached()
+    {
+        var heaterService = new Mock<IHeaterService>(MockBehavior.Strict);
+        var fanService = new Mock<IFanService>(MockBehavior.Strict);
+        var sensorService = new Mock<ISensorService>(MockBehavior.Strict);
+
+        heaterService.Setup(service => service.SetAllHeatersAsync(3)).Returns(Task.CompletedTask).Verifiable();
+        fanService.Setup(service => service.SetAllFansAsync(false)).Returns(Task.CompletedTask).Verifiable();
+        sensorService.Setup(service => service.GetAverageTemperatureAsync()).ReturnsAsync(20.0).Verifiable();
+
+        var strategy = new HeatUpStrategy(
+            heaterService.Object,
+            fanService.Object,
+            sensorService.Object,
+            (_, _) => Task.CompletedTask);
+
+        var result = await strategy.ExecuteAsync(18.0, 20.0, 5);
+
+        Assert.Equal(20.0, result, precision: 5);
+        heaterService.Verify(service => service.SetAllHeatersAsync(3), Times.Once);
+        fanService.Verify(service => service.SetAllFansAsync(false), Times.Once);
+        sensorService.Verify(service => service.GetAverageTemperatureAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AlreadyAtTarget_ReturnsWithoutChangingDevices()
+    {
+        var heaterService = new Mock<IHeaterService>(MockBehavior.Strict);
+        var fanService = new Mock<IFanService>(MockBehavior.Strict);
+        var sensorService = new Mock<ISensorService>(MockBehavior.Strict);
+
+        var strategy = new HeatUpStrategy(
+            heaterService.Object,
+            fanService.Object,
+            sensorService.Object,
+            (_, _) => Task.CompletedTask);
+
+        var result = await strategy.ExecuteAsync(20.0, 20.0, 5);
+
+        Assert.Equal(20.0, result, precision: 5);
+        heaterService.Verify(service => service.SetAllHeatersAsync(It.IsAny<int>()), Times.Never);
+        fanService.Verify(service => service.SetAllFansAsync(It.IsAny<bool>()), Times.Never);
+        sensorService.Verify(service => service.GetAverageTemperatureAsync(), Times.Never);
+    }
+}

--- a/UglyClient.Tests/Strategies/HoldStrategyTests.cs
+++ b/UglyClient.Tests/Strategies/HoldStrategyTests.cs
@@ -1,0 +1,84 @@
+using Moq;
+using UglyClient.Services;
+using UglyClient.Strategies;
+
+namespace UglyClient.Tests.Strategies;
+
+/// <summary>
+/// Unit tests for <see cref="HoldStrategy"/>.
+/// </summary>
+public class HoldStrategyTests
+{
+    [Fact]
+    public async Task ExecuteAsync_BelowTarget_AppliesMinimalHeatingAndPollsTemperature()
+    {
+        var heaterService = new Mock<IHeaterService>(MockBehavior.Strict);
+        var fanService = new Mock<IFanService>(MockBehavior.Strict);
+        var sensorService = new Mock<ISensorService>(MockBehavior.Strict);
+
+        heaterService.Setup(service => service.SetAllHeatersAsync(1)).Returns(Task.CompletedTask).Verifiable();
+        fanService.Setup(service => service.SetAllFansAsync(false)).Returns(Task.CompletedTask).Verifiable();
+        sensorService.Setup(service => service.GetAverageTemperatureAsync()).ReturnsAsync(16.0).Verifiable();
+
+        var strategy = new HoldStrategy(
+            heaterService.Object,
+            fanService.Object,
+            sensorService.Object,
+            (_, _) => Task.CompletedTask);
+
+        var result = await strategy.ExecuteAsync(15.0, 16.0, 1);
+
+        Assert.Equal(16.0, result, precision: 5);
+        heaterService.Verify(service => service.SetAllHeatersAsync(1), Times.Once);
+        fanService.Verify(service => service.SetAllFansAsync(false), Times.Once);
+        sensorService.Verify(service => service.GetAverageTemperatureAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AboveTarget_AppliesCoolingAndPollsTemperature()
+    {
+        var heaterService = new Mock<IHeaterService>(MockBehavior.Strict);
+        var fanService = new Mock<IFanService>(MockBehavior.Strict);
+        var sensorService = new Mock<ISensorService>(MockBehavior.Strict);
+
+        heaterService.Setup(service => service.SetAllHeatersAsync(0)).Returns(Task.CompletedTask).Verifiable();
+        fanService.Setup(service => service.SetAllFansAsync(true)).Returns(Task.CompletedTask).Verifiable();
+        sensorService.Setup(service => service.GetAverageTemperatureAsync()).ReturnsAsync(16.0).Verifiable();
+
+        var strategy = new HoldStrategy(
+            heaterService.Object,
+            fanService.Object,
+            sensorService.Object,
+            (_, _) => Task.CompletedTask);
+
+        var result = await strategy.ExecuteAsync(17.5, 16.0, 1);
+
+        Assert.Equal(16.0, result, precision: 5);
+        heaterService.Verify(service => service.SetAllHeatersAsync(0), Times.Once);
+        fanService.Verify(service => service.SetAllFansAsync(true), Times.Once);
+        sensorService.Verify(service => service.GetAverageTemperatureAsync(), Times.Once);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_AtTarget_PollsWithoutChangingDevices()
+    {
+        var heaterService = new Mock<IHeaterService>(MockBehavior.Strict);
+        var fanService = new Mock<IFanService>(MockBehavior.Strict);
+        var sensorService = new Mock<ISensorService>(MockBehavior.Strict);
+
+        sensorService.Setup(service => service.GetAverageTemperatureAsync()).ReturnsAsync(16.0).Verifiable();
+
+        var strategy = new HoldStrategy(
+            heaterService.Object,
+            fanService.Object,
+            sensorService.Object,
+            (_, _) => Task.CompletedTask);
+
+        var result = await strategy.ExecuteAsync(16.0, 16.0, 1);
+
+        Assert.Equal(16.0, result, precision: 5);
+        heaterService.Verify(service => service.SetAllHeatersAsync(It.IsAny<int>()), Times.Never);
+        fanService.Verify(service => service.SetAllFansAsync(It.IsAny<bool>()), Times.Never);
+        sensorService.Verify(service => service.GetAverageTemperatureAsync(), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ITemperatureControlStrategy` plus concrete heat-up, cool-down, and hold strategies
- replace the legacy `Program.cs` temperature helper methods with strategy-driven phase execution
- add unit tests covering all three strategy classes

Closes #15