### PR TITLE
#19 – DeviceServiceFactory (Factory Pattern)

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Threading.Tasks;
-using UglyClient.Adapters;
 using UglyClient.Config;
-using UglyClient.Controllers;
-using UglyClient.Interfaces;
 using UglyClient.Services;
 
 class Program
@@ -18,23 +15,11 @@ class Program
             ApiKey: "u007-key"
         );
 
-        using var httpService = new HttpService(config.BaseUrl, config.ApiKey);
-
-        // Adapter Pattern: each sensor adapter wraps its own HTTP call and converts
-        // the raw response type to double, conforming to ISensor.
-        ISensor sensor1Adapter = new Sensor1Adapter(httpService);
-        ISensor sensor2Adapter = new Sensor2Adapter(httpService);
-        ISensor sensor3Adapter = new Sensor3Adapter(httpService);
-        ISensor[] sensorAdapters = [sensor1Adapter, sensor2Adapter, sensor3Adapter];
-        ISensorService sensorService = new SensorService(sensorAdapters);
-
-        // Facade / Service layer: FanService encapsulates all fan-related HTTP calls.
-        IFanService fanService = new FanService(httpService, config.FanCount);
-
-        // Facade / Service layer: HeaterService encapsulates all heater-related HTTP calls.
-        IHeaterService heaterService = new HeaterService(httpService, config.HeaterCount);
-        var temperatureController = new TemperatureController(fanService, heaterService, sensorService);
-        ISimulationService simulationService = new SimulationService(httpService, temperatureController);
+        var services = DeviceServiceFactory.Create(config);
+        var fanService = services.FanService;
+        var heaterService = services.HeaterService;
+        var sensorService = services.SensorService;
+        var simulationService = services.SimulationService;
 
         while (true)
         {

--- a/Services/DeviceServiceFactory.cs
+++ b/Services/DeviceServiceFactory.cs
@@ -1,0 +1,57 @@
+using UglyClient.Adapters;
+using UglyClient.Config;
+using UglyClient.Controllers;
+using UglyClient.Interfaces;
+
+namespace UglyClient.Services;
+
+/// <summary>
+/// Holds the fully-wired service instances produced by <see cref="DeviceServiceFactory.Create"/>.
+/// All properties expose interfaces so callers never depend on concrete service types.
+/// </summary>
+/// <param name="FanService">The fan control service.</param>
+/// <param name="HeaterService">The heater control service.</param>
+/// <param name="SensorService">The sensor read service.</param>
+/// <param name="SimulationService">The simulation-lifecycle service.</param>
+/// <param name="TemperatureController">The orchestrator that runs the multi-phase temperature cycle.</param>
+public record DeviceServices(
+    IFanService FanService,
+    IHeaterService HeaterService,
+    ISensorService SensorService,
+    ISimulationService SimulationService,
+    TemperatureController TemperatureController);
+
+/// <summary>
+/// Centralises the construction of all concrete service types so that <c>Program.cs</c>
+/// never directly instantiates a service class.
+/// </summary>
+public static class DeviceServiceFactory
+{
+    /// <summary>
+    /// Builds and wires every service required by the simulation client from the supplied config.
+    /// </summary>
+    /// <param name="config">The simulation configuration. Must not be <see langword="null"/>.</param>
+    /// <returns>A <see cref="DeviceServices"/> record whose properties are all interface-typed.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="config"/> is <see langword="null"/>.</exception>
+    public static DeviceServices Create(SimulationConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var httpService = new HttpService(config.BaseUrl, config.ApiKey);
+
+        ISensor[] sensorAdapters =
+        [
+            new Sensor1Adapter(httpService),
+            new Sensor2Adapter(httpService),
+            new Sensor3Adapter(httpService),
+        ];
+
+        ISensorService sensorService = new SensorService(sensorAdapters);
+        IFanService fanService = new FanService(httpService, config.FanCount);
+        IHeaterService heaterService = new HeaterService(httpService, config.HeaterCount);
+        var temperatureController = new TemperatureController(fanService, heaterService, sensorService);
+        ISimulationService simulationService = new SimulationService(httpService, temperatureController);
+
+        return new DeviceServices(fanService, heaterService, sensorService, simulationService, temperatureController);
+    }
+}

--- a/UglyClient.Tests/Services/DeviceServiceFactoryTests.cs
+++ b/UglyClient.Tests/Services/DeviceServiceFactoryTests.cs
@@ -1,0 +1,104 @@
+using UglyClient.Config;
+using UglyClient.Controllers;
+using UglyClient.Services;
+
+namespace UglyClient.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="DeviceServiceFactory"/>.
+/// </summary>
+public class DeviceServiceFactoryTests
+{
+    private static SimulationConfig ValidConfig => new(
+        FanCount: 3,
+        HeaterCount: 3,
+        SensorCount: 3,
+        BaseUrl: "http://localhost/",
+        ApiKey: "test-key");
+
+    [Fact]
+    public void Create_NullConfig_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => DeviceServiceFactory.Create(null!));
+    }
+
+    [Fact]
+    public void Create_ValidConfig_ReturnsFanService()
+    {
+        var result = DeviceServiceFactory.Create(ValidConfig);
+
+        Assert.NotNull(result.FanService);
+    }
+
+    [Fact]
+    public void Create_ValidConfig_ReturnsHeaterService()
+    {
+        var result = DeviceServiceFactory.Create(ValidConfig);
+
+        Assert.NotNull(result.HeaterService);
+    }
+
+    [Fact]
+    public void Create_ValidConfig_ReturnsSensorService()
+    {
+        var result = DeviceServiceFactory.Create(ValidConfig);
+
+        Assert.NotNull(result.SensorService);
+    }
+
+    [Fact]
+    public void Create_ValidConfig_ReturnsSimulationService()
+    {
+        var result = DeviceServiceFactory.Create(ValidConfig);
+
+        Assert.NotNull(result.SimulationService);
+    }
+
+    [Fact]
+    public void Create_ValidConfig_ReturnsTemperatureController()
+    {
+        var result = DeviceServiceFactory.Create(ValidConfig);
+
+        Assert.NotNull(result.TemperatureController);
+    }
+
+    [Fact]
+    public void Create_ValidConfig_FanServiceImplementsIFanService()
+    {
+        var result = DeviceServiceFactory.Create(ValidConfig);
+
+        Assert.IsAssignableFrom<IFanService>(result.FanService);
+    }
+
+    [Fact]
+    public void Create_ValidConfig_HeaterServiceImplementsIHeaterService()
+    {
+        var result = DeviceServiceFactory.Create(ValidConfig);
+
+        Assert.IsAssignableFrom<IHeaterService>(result.HeaterService);
+    }
+
+    [Fact]
+    public void Create_ValidConfig_SensorServiceImplementsISensorService()
+    {
+        var result = DeviceServiceFactory.Create(ValidConfig);
+
+        Assert.IsAssignableFrom<ISensorService>(result.SensorService);
+    }
+
+    [Fact]
+    public void Create_ValidConfig_SimulationServiceImplementsISimulationService()
+    {
+        var result = DeviceServiceFactory.Create(ValidConfig);
+
+        Assert.IsAssignableFrom<ISimulationService>(result.SimulationService);
+    }
+
+    [Fact]
+    public void Create_ValidConfig_TemperatureControllerIsCorrectType()
+    {
+        var result = DeviceServiceFactory.Create(ValidConfig);
+
+        Assert.IsType<TemperatureController>(result.TemperatureController);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #19

Centralises all service construction behind a single `DeviceServiceFactory.Create(SimulationConfig)` call, so `Program.cs` never directly instantiates a concrete service class.

## Changes

### `Services/DeviceServiceFactory.cs` (new)
- `DeviceServices` record — holds all wired-up service instances, all properties are interface-typed (except `TemperatureController`, which has no interface)
- `DeviceServiceFactory` static class with `Create(SimulationConfig config)` method that:
  - Constructs `HttpService` from config
  - Constructs the three sensor adapters and wires them into `SensorService`
  - Constructs `FanService` and `HeaterService` with the shared `HttpService`
  - Constructs `TemperatureController` with the three service interfaces
  - Constructs `SimulationService` with `HttpService` and `TemperatureController`
  - Returns all of the above as a `DeviceServices` record

### `Program.cs` (modified)
- Replaced all `new FanService(...)`, `new HeaterService(...)`, `new SensorService(...)`, `new SimulationService(...)`, `new HttpService(...)`, and adapter instantiations with a single `DeviceServiceFactory.Create(config)` call
- Removed unused `using` directives (`UglyClient.Adapters`, `UglyClient.Controllers`, `UglyClient.Interfaces`)
- `Main()` now only: builds config → calls factory → runs menu loop

### `UglyClient.Tests/Services/DeviceServiceFactoryTests.cs` (new)
- 10 unit tests covering:
  - Null config guard (`ArgumentNullException`)
  - All 5 returned properties are non-null
  - All 4 service properties implement the correct interfaces
  - `TemperatureController` is the correct concrete type

## Test results
```
Test summary: total: 66, failed: 0, succeeded: 66, skipped: 0
```