### PR TITLE
#17 – XML documentation and dead code cleanup

### DIFF
--- a/Adapters/Sensor1Adapter.cs
+++ b/Adapters/Sensor1Adapter.cs
@@ -3,44 +3,26 @@ using UglyClient.Services;
 
 namespace UglyClient.Adapters;
 
-/// <summary>
-/// Adapter that wraps the Sensor 1 HTTP endpoint and converts its raw <see cref="string"/>
-/// response into a <see cref="double"/> temperature value, conforming to <see cref="ISensor"/>.
-/// </summary>
+/// <summary>Adapts the Sensor 1 HTTP endpoint (plain text <see cref="double"/>) to <see cref="ISensor"/>.</summary>
 /// <remarks>
 /// Sensor 1 returns its reading as a plain text string (e.g. <c>"21.5"</c>).
-/// This adapter parses that string with <see cref="double.Parse(string)"/> so that
-/// callers never need to know the underlying representation.
 /// </remarks>
 public sealed class Sensor1Adapter : ISensor
 {
-    /// <summary>The shared HTTP service used to make requests to the sensor API.</summary>
     private readonly IHttpService _httpService;
 
-    /// <summary>
-    /// Gets the fixed identifier of Sensor 1.
-    /// </summary>
+    /// <summary>Fixed identifier for Sensor 1.</summary>
     public int SensorId => 1;
 
-    /// <summary>
-    /// Initialises a new instance of <see cref="Sensor1Adapter"/>.
-    /// </summary>
-    /// <param name="httpService">
-    /// The shared HTTP service used for sensor requests.
-    /// </param>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="httpService"/> is <see langword="null"/>.
-    /// </exception>
+    /// <summary>Initialises a new instance of <see cref="Sensor1Adapter"/>.</summary>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="httpService"/> is <see langword="null"/>.</exception>
     public Sensor1Adapter(IHttpService httpService)
     {
         _httpService = httpService ?? throw new ArgumentNullException(nameof(httpService));
     }
 
     /// <inheritdoc />
-    /// <remarks>
-    /// Calls <c>GET api/Sensor/sensor1</c>. The API returns the temperature as a
-    /// plain <see cref="string"/> which is parsed to <see cref="double"/>.
-    /// </remarks>
+    /// <remarks>Calls <c>GET api/Sensor/sensor1</c>. Returns a plain text string parsed to <see cref="double"/>.</remarks>
     public async Task<double> GetTemperatureAsync()
     {
         string content;

--- a/Adapters/Sensor2Adapter.cs
+++ b/Adapters/Sensor2Adapter.cs
@@ -3,46 +3,26 @@ using UglyClient.Services;
 
 namespace UglyClient.Adapters;
 
-/// <summary>
-/// Adapter that wraps the Sensor 2 HTTP endpoint and converts its raw <see cref="int"/>
-/// response into a <see cref="double"/> temperature value, conforming to <see cref="ISensor"/>.
-/// </summary>
+/// <summary>Adapts the Sensor 2 HTTP endpoint (plain integer string) to <see cref="ISensor"/>.</summary>
 /// <remarks>
-/// Sensor 2 returns its reading as a plain integer string (e.g. <c>"21"</c>).
-/// This adapter parses that integer with <see cref="int.TryParse(string, out int)"/> and
-/// widens it to <see cref="double"/> so that callers never need to know the underlying
-/// representation.
+/// Sensor 2 returns its reading as a plain integer string (e.g. <c>"21"</c>), widened to <see cref="double"/>.
 /// </remarks>
 public sealed class Sensor2Adapter : ISensor
 {
-    /// <summary>The shared HTTP service used to make requests to the sensor API.</summary>
     private readonly IHttpService _httpService;
 
-    /// <summary>
-    /// Gets the fixed identifier of Sensor 2.
-    /// </summary>
+    /// <summary>Fixed identifier for Sensor 2.</summary>
     public int SensorId => 2;
 
-    /// <summary>
-    /// Initialises a new instance of <see cref="Sensor2Adapter"/>.
-    /// </summary>
-    /// <param name="httpService">
-    /// The shared HTTP service used for sensor requests.
-    /// </param>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="httpService"/> is <see langword="null"/>.
-    /// </exception>
+    /// <summary>Initialises a new instance of <see cref="Sensor2Adapter"/>.</summary>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="httpService"/> is <see langword="null"/>.</exception>
     public Sensor2Adapter(IHttpService httpService)
     {
         _httpService = httpService ?? throw new ArgumentNullException(nameof(httpService));
     }
 
     /// <inheritdoc />
-    /// <remarks>
-    /// Calls <c>GET api/Sensor/sensor2</c>. The API returns the temperature as an
-    /// integer string which is parsed to <see cref="int"/> and then widened to
-    /// <see cref="double"/>.
-    /// </remarks>
+    /// <remarks>Calls <c>GET api/Sensor/sensor2</c>. Returns an integer string parsed to <see cref="double"/>.</remarks>
     public async Task<double> GetTemperatureAsync()
     {
         string content;

--- a/Adapters/Sensor3Adapter.cs
+++ b/Adapters/Sensor3Adapter.cs
@@ -3,46 +3,26 @@ using UglyClient.Services;
 
 namespace UglyClient.Adapters;
 
-/// <summary>
-/// Adapter that wraps the Sensor 3 HTTP endpoint and converts its raw <see cref="decimal"/>
-/// response into a <see cref="double"/> temperature value, conforming to <see cref="ISensor"/>.
-/// </summary>
+/// <summary>Adapts the Sensor 3 HTTP endpoint (decimal string) to <see cref="ISensor"/>.</summary>
 /// <remarks>
-/// Sensor 3 returns its reading as a decimal string (e.g. <c>"21.75"</c>).
-/// This adapter parses that decimal with <see cref="decimal.TryParse(string, out decimal)"/>
-/// and casts it to <see cref="double"/> so that callers never need to know the underlying
-/// representation.
+/// Sensor 3 returns its reading as a decimal string (e.g. <c>"21.75"</c>), cast to <see cref="double"/>.
 /// </remarks>
 public sealed class Sensor3Adapter : ISensor
 {
-    /// <summary>The shared HTTP service used to make requests to the sensor API.</summary>
     private readonly IHttpService _httpService;
 
-    /// <summary>
-    /// Gets the fixed identifier of Sensor 3.
-    /// </summary>
+    /// <summary>Fixed identifier for Sensor 3.</summary>
     public int SensorId => 3;
 
-    /// <summary>
-    /// Initialises a new instance of <see cref="Sensor3Adapter"/>.
-    /// </summary>
-    /// <param name="httpService">
-    /// The shared HTTP service used for sensor requests.
-    /// </param>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="httpService"/> is <see langword="null"/>.
-    /// </exception>
+    /// <summary>Initialises a new instance of <see cref="Sensor3Adapter"/>.</summary>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="httpService"/> is <see langword="null"/>.</exception>
     public Sensor3Adapter(IHttpService httpService)
     {
         _httpService = httpService ?? throw new ArgumentNullException(nameof(httpService));
     }
 
     /// <inheritdoc />
-    /// <remarks>
-    /// Calls <c>GET api/Sensor/sensor3</c>. The API returns the temperature as a
-    /// decimal string which is parsed to <see cref="decimal"/> and then cast to
-    /// <see cref="double"/>.
-    /// </remarks>
+    /// <remarks>Calls <c>GET api/Sensor/sensor3</c>. Returns a decimal string cast to <see cref="double"/>.</remarks>
     public async Task<double> GetTemperatureAsync()
     {
         string content;

--- a/Config/SimulationConfig.cs
+++ b/Config/SimulationConfig.cs
@@ -1,16 +1,9 @@
 namespace UglyClient.Config;
 
-/// <summary>
-/// Holds all configuration values for the simulation client, eliminating magic numbers
-/// and hardcoded strings from the rest of the codebase.
-/// </summary>
-/// <remarks>
-/// A single instance is constructed in <c>Program.Main</c> and passed via constructor
-/// injection to every service that requires it.
-/// </remarks>
-/// <param name="FanCount">Total number of fans managed by the simulation.</param>
-/// <param name="HeaterCount">Total number of heaters managed by the simulation.</param>
-/// <param name="SensorCount">Total number of temperature sensors managed by the simulation.</param>
+/// <summary>Immutable configuration for the simulation client.</summary>
+/// <param name="FanCount">Total number of fans in the simulation.</param>
+/// <param name="HeaterCount">Total number of heaters in the simulation.</param>
+/// <param name="SensorCount">Total number of temperature sensors in the simulation.</param>
 /// <param name="BaseUrl">Base URL of the environment simulation API (including trailing slash).</param>
 /// <param name="ApiKey">API key sent in the <c>X-Api-Key</c> request header.</param>
 public record SimulationConfig(

--- a/Controllers/TemperatureController.cs
+++ b/Controllers/TemperatureController.cs
@@ -4,33 +4,14 @@ using UglyClient.Strategies;
 
 namespace UglyClient.Controllers;
 
-/// <summary>
-/// Orchestrates the end-to-end temperature-control cycle by selecting and executing the
-/// appropriate strategy for each phase.
-/// </summary>
+/// <summary>Orchestrates the end-to-end temperature-control cycle by selecting and executing the appropriate strategy for each phase.</summary>
 public class TemperatureController
 {
-    /// <summary>
-    /// The fan facade used by phase strategies.
-    /// </summary>
     private readonly IFanService _fanService;
-
-    /// <summary>
-    /// The heater facade used by phase strategies.
-    /// </summary>
     private readonly IHeaterService _heaterService;
-
-    /// <summary>
-    /// The sensor facade used to read temperatures and construct phase strategies.
-    /// </summary>
     private readonly ISensorService _sensorService;
 
-    /// <summary>
-    /// Initialises a new instance of <see cref="TemperatureController"/>.
-    /// </summary>
-    /// <param name="fanService">The fan facade used during each temperature-control phase.</param>
-    /// <param name="heaterService">The heater facade used during each temperature-control phase.</param>
-    /// <param name="sensorService">The sensor facade used to read the current average temperature.</param>
+    /// <summary>Initialises a new instance of <see cref="TemperatureController"/>.</summary>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="fanService"/>, <paramref name="heaterService"/>, or
     /// <paramref name="sensorService"/> is <see langword="null"/>.
@@ -45,14 +26,7 @@ public class TemperatureController
         _sensorService = sensorService ?? throw new ArgumentNullException(nameof(sensorService));
     }
 
-    /// <summary>
-    /// Runs a single control phase by delegating to the supplied strategy.
-    /// </summary>
-    /// <param name="strategy">The phase strategy to execute.</param>
-    /// <param name="currentTemperature">The average temperature observed at the start of the phase.</param>
-    /// <param name="targetTemperature">The target temperature for the phase.</param>
-    /// <param name="durationSeconds">The maximum number of one-second iterations the phase may run.</param>
-    /// <param name="cancellationToken">The token used to cancel the phase cleanly.</param>
+    /// <summary>Runs a single control phase by delegating to <paramref name="strategy"/>.</summary>
     /// <returns>The last temperature returned by the strategy.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="strategy"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="durationSeconds"/> is negative.</exception>
@@ -74,11 +48,7 @@ public class TemperatureController
             cancellationToken);
     }
 
-    /// <summary>
-    /// Runs the fixed multi-phase simulation cycle until the final hold phase is cancelled.
-    /// </summary>
-    /// <param name="cancellationToken">The token used to cancel the cycle cleanly.</param>
-    /// <returns>A <see cref="Task"/> that completes when the cycle finishes or is cancelled.</returns>
+    /// <summary>Runs the fixed multi-phase simulation cycle until cancelled.</summary>
     public virtual async Task RunFullCycleAsync(CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/Interfaces/ISensor.cs
+++ b/Interfaces/ISensor.cs
@@ -1,27 +1,14 @@
 namespace UglyClient.Interfaces;
 
-/// <summary>
-/// Defines the contract for a temperature sensor.
-/// Implementing this interface as part of the Adapter Pattern ensures that all
-/// sensor adapters — regardless of their underlying HTTP response format — expose
-/// a unified <see cref="GetTemperatureAsync"/> method that returns a <see cref="double"/>.
-/// </summary>
+/// <summary>Contract for a temperature sensor adapter.</summary>
 public interface ISensor
 {
-    /// <summary>
-    /// Gets the one-based identifier of the sensor represented by this adapter.
-    /// </summary>
+    /// <summary>One-based sensor identifier.</summary>
     int SensorId { get; }
 
-    /// <summary>
-    /// Asynchronously retrieves the current temperature reading from the sensor.
-    /// </summary>
-    /// <returns>
-    /// A <see cref="Task{TResult}"/> that resolves to the sensor temperature as a
-    /// <see cref="double"/> (degrees Celsius).
-    /// </returns>
+    /// <summary>Returns the current sensor temperature in degrees Celsius.</summary>
     /// <exception cref="UglyClient.Services.DeviceServiceException">
-    /// Thrown when the sensor reading cannot be retrieved successfully.
+    /// Thrown when the reading cannot be retrieved.
     /// </exception>
     Task<double> GetTemperatureAsync();
 }

--- a/Interfaces/ITemperatureControlStrategy.cs
+++ b/Interfaces/ITemperatureControlStrategy.cs
@@ -1,17 +1,13 @@
 namespace UglyClient.Interfaces;
 
-/// <summary>
-/// Defines the contract for a temperature-control algorithm used during a simulation phase.
-/// </summary>
+/// <summary>Contract for a temperature-control algorithm used during a simulation phase.</summary>
 public interface ITemperatureControlStrategy
 {
-    /// <summary>
-    /// Executes the temperature-control algorithm for the supplied phase settings.
-    /// </summary>
-    /// <param name="currentTemperature">The temperature observed at the start of the phase.</param>
-    /// <param name="targetTemperature">The desired target temperature for the phase.</param>
-    /// <param name="durationSeconds">The maximum number of one-second iterations to perform.</param>
-    /// <param name="cancellationToken">The token used to cancel the phase while it is running.</param>
+    /// <summary>Executes the temperature-control algorithm for the supplied phase settings.</summary>
+    /// <param name="currentTemperature">Temperature observed at the start of the phase.</param>
+    /// <param name="targetTemperature">Desired target temperature for the phase.</param>
+    /// <param name="durationSeconds">Maximum number of one-second iterations to perform.</param>
+    /// <param name="cancellationToken">Token used to cancel the phase while running.</param>
     /// <returns>The last temperature observed before the phase completed.</returns>
     Task<double> ExecuteAsync(
         double currentTemperature,

--- a/Models/FanDTO.cs
+++ b/Models/FanDTO.cs
@@ -1,19 +1,11 @@
 namespace UglyClient.Models;
 
-/// <summary>
-/// Data Transfer Object representing the state of a fan device as returned by the
-/// <c>GET api/fans/{id}/state</c> endpoint.
-/// </summary>
+/// <summary>DTO for fan state returned by <c>GET api/fans/{id}/state</c>.</summary>
 public class FanDTO
 {
-    /// <summary>
-    /// Gets or sets the unique identifier of the fan.
-    /// </summary>
+    /// <summary>Fan identifier.</summary>
     public int Id { get; set; }
 
-    /// <summary>
-    /// Gets or sets a value indicating whether the fan is currently switched on.
-    /// <c>true</c> means the fan is on; <c>false</c> means the fan is off.
-    /// </summary>
+    /// <summary><c>true</c> if the fan is on; <c>false</c> if off.</summary>
     public bool IsOn { get; set; }
 }

--- a/Services/FanService.cs
+++ b/Services/FanService.cs
@@ -3,45 +3,14 @@ using UglyClient.Models;
 
 namespace UglyClient.Services;
 
-/// <summary>
-/// Concrete implementation of <see cref="IFanService"/> that communicates with the environment
-/// simulation API via an injected <see cref="IHttpService"/>.
-/// All fan-related HTTP calls and their error handling are encapsulated here; no other class
-/// should make raw HTTP calls for fan operations.
-/// </summary>
+/// <summary>Concrete <see cref="IFanService"/> implementation using an injected <see cref="IHttpService"/>.</summary>
 public class FanService : IFanService
 {
-    /// <summary>
-    /// The shared HTTP service used to communicate with the simulation API.
-    /// </summary>
     private readonly IHttpService _httpService;
-
-    /// <summary>
-    /// The total number of fans managed by the simulation.
-    /// Used by <see cref="SetAllFansAsync"/> and <see cref="GetAllFanStatesAsync"/> to
-    /// iterate over all fan IDs (1 … <see cref="_fanCount"/>).
-    /// </summary>
     private readonly int _fanCount;
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
 
-    /// <summary>
-    /// Shared <see cref="JsonSerializerOptions"/> configured for case-insensitive property
-    /// name matching, compatible with the simulation API's JSON responses.
-    /// </summary>
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true
-    };
-
-    /// <summary>
-    /// Initialises a new instance of <see cref="FanService"/> with the specified
-    /// <see cref="IHttpService"/> and optional fan count.
-    /// </summary>
-    /// <param name="httpService">
-    /// The shared HTTP service used for fan requests. Must not be <see langword="null"/>.
-    /// </param>
-    /// <param name="fanCount">
-    /// The total number of fans in the simulation. Defaults to <c>3</c> when not supplied.
-    /// </param>
+    /// <summary>Initialises a new instance of <see cref="FanService"/>.</summary>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="httpService"/> is <c>null</c>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="fanCount"/> is less than 1.</exception>
     public FanService(IHttpService httpService, int fanCount = 3)

--- a/Services/HeaterService.cs
+++ b/Services/HeaterService.cs
@@ -1,35 +1,12 @@
 namespace UglyClient.Services;
 
-/// <summary>
-/// Concrete implementation of <see cref="IHeaterService"/> that communicates with the environment
-/// simulation API via an injected <see cref="IHttpService"/>.
-/// All heater-related HTTP calls and their error handling are encapsulated here; no other class
-/// should make raw HTTP calls for heater operations.
-/// </summary>
+/// <summary>Concrete <see cref="IHeaterService"/> implementation using an injected <see cref="IHttpService"/>.</summary>
 public class HeaterService : IHeaterService
 {
-    /// <summary>
-    /// The shared HTTP service used to communicate with the simulation API.
-    /// </summary>
     private readonly IHttpService _httpService;
-
-    /// <summary>
-    /// The total number of heaters managed by the simulation.
-    /// Used by <see cref="SetAllHeatersAsync"/> and <see cref="GetAllHeaterLevelsAsync"/> to
-    /// iterate over all heater IDs (1 … <see cref="_heaterCount"/>).
-    /// </summary>
     private readonly int _heaterCount;
 
-    /// <summary>
-    /// Initialises a new instance of <see cref="HeaterService"/> with the specified
-    /// <see cref="IHttpService"/> and optional heater count.
-    /// </summary>
-    /// <param name="httpService">
-    /// The shared HTTP service used for heater requests. Must not be <see langword="null"/>.
-    /// </param>
-    /// <param name="heaterCount">
-    /// The total number of heaters in the simulation. Defaults to <c>3</c> when not supplied.
-    /// </param>
+    /// <summary>Initialises a new instance of <see cref="HeaterService"/>.</summary>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="httpService"/> is <c>null</c>.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="heaterCount"/> is less than 1.</exception>
     public HeaterService(IHttpService httpService, int heaterCount = 3)

--- a/Services/HttpService.cs
+++ b/Services/HttpService.cs
@@ -2,52 +2,16 @@ using System.Text;
 
 namespace UglyClient.Services;
 
-/// <summary>
-/// Shared HTTP communication service that owns and configures the underlying <see cref="HttpClient"/>.
-/// This is the single place in the codebase where <see cref="HttpClient"/> is constructed.
-/// All service classes (<c>FanService</c>, <c>HeaterService</c>, <c>SensorService</c>,
-/// <c>SimulationService</c>) receive an instance of this class via constructor injection and
-/// never create their own <see cref="HttpClient"/>.
-/// </summary>
+/// <summary>Shared HTTP service that owns the <see cref="HttpClient"/> and routes all API calls.</summary>
 public sealed class HttpService : IHttpService, IDisposable
 {
-    /// <summary>
-    /// The name of the HTTP request header used for API key authentication.
-    /// </summary>
     private const string ApiKeyHeaderName = "X-Api-Key";
-
-    /// <summary>
-    /// The media type sent in the Content-Type header for POST requests containing a JSON body.
-    /// </summary>
     private const string JsonMediaType = "application/json";
-
-    /// <summary>
-    /// The underlying <see cref="HttpClient"/> owned exclusively by this service.
-    /// It is configured once in the constructor and reused for the lifetime of this instance.
-    /// </summary>
     private readonly HttpClient _httpClient;
-
-    /// <summary>
-    /// Indicates whether this service owns the lifetime of the underlying
-    /// <see cref="HttpClient"/>.
-    /// </summary>
     private readonly bool _ownsHttpClient;
 
-    /// <summary>
-    /// Initialises a new instance of <see cref="HttpService"/>, constructing and configuring
-    /// the underlying <see cref="HttpClient"/> with the supplied base URL and API key.
-    /// </summary>
-    /// <param name="baseUrl">
-    /// The base URL of the API (e.g. <c>https://envrosym.azurewebsites.net/</c>).
-    /// All relative endpoint paths supplied to <see cref="GetAsync"/> and
-    /// <see cref="PostAsync"/> are resolved against this URL.
-    /// </param>
-    /// <param name="apiKey">
-    /// The API key injected into every outgoing request via the <c>X-Api-Key</c> header.
-    /// </param>
-    /// <exception cref="ArgumentException">
-    /// Thrown when <paramref name="baseUrl"/> or <paramref name="apiKey"/> is null or whitespace.
-    /// </exception>
+    /// <summary>Constructs and configures an <see cref="HttpClient"/> with the supplied base URL and API key.</summary>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="baseUrl"/> or <paramref name="apiKey"/> is null or whitespace.</exception>
     public HttpService(string baseUrl, string apiKey)
     {
         if (string.IsNullOrWhiteSpace(baseUrl))
@@ -65,43 +29,21 @@ public sealed class HttpService : IHttpService, IDisposable
         _ownsHttpClient = true;
     }
 
-    /// <summary>
-    /// Initialises a new instance of <see cref="HttpService"/> around an existing
-    /// <see cref="HttpClient"/>.
-    /// </summary>
-    /// <param name="httpClient">The pre-configured client to use for requests.</param>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="httpClient"/> is <see langword="null"/>.
-    /// </exception>
+    /// <summary>Wraps an existing <see cref="HttpClient"/> without taking ownership of its lifetime.</summary>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="httpClient"/> is <see langword="null"/>.</exception>
     public HttpService(HttpClient httpClient)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _ownsHttpClient = false;
     }
 
-    /// <summary>
-    /// Sends an HTTP GET request to the specified endpoint and returns the response body as a string.
-    /// </summary>
-    /// <param name="endpoint">The relative endpoint path (e.g. <c>api/fans/1</c>).</param>
-    /// <returns>The response content as a raw string.</returns>
-    /// <exception cref="DeviceServiceException">
-    /// Thrown when the request cannot be completed successfully.
-    /// </exception>
+    /// <inheritdoc/>
     public async Task<string> GetAsync(string endpoint)
     {
         return await SendAsync(() => new HttpRequestMessage(HttpMethod.Get, endpoint));
     }
 
-    /// <summary>
-    /// Sends an HTTP POST request to the specified endpoint with the supplied JSON body
-    /// and returns the response body as a string.
-    /// </summary>
-    /// <param name="endpoint">The relative endpoint path (e.g. <c>api/fans/1/state</c>).</param>
-    /// <param name="body">The JSON-serialised request body to send.</param>
-    /// <returns>The response content as a raw string.</returns>
-    /// <exception cref="DeviceServiceException">
-    /// Thrown when the request cannot be completed successfully.
-    /// </exception>
+    /// <inheritdoc/>
     public async Task<string> PostAsync(string endpoint, string body)
     {
         return await SendAsync(() => new HttpRequestMessage(HttpMethod.Post, endpoint)
@@ -110,15 +52,6 @@ public sealed class HttpService : IHttpService, IDisposable
         });
     }
 
-    /// <summary>
-    /// Sends an HTTP request and normalises transport and status code failures into a
-    /// <see cref="DeviceServiceException"/>.
-    /// </summary>
-    /// <param name="createRequest">Creates the request to send.</param>
-    /// <returns>The response body as a string.</returns>
-    /// <exception cref="DeviceServiceException">
-    /// Thrown when the request fails or returns a non-success status code.
-    /// </exception>
     private async Task<string> SendAsync(Func<HttpRequestMessage> createRequest)
     {
         try
@@ -143,9 +76,7 @@ public sealed class HttpService : IHttpService, IDisposable
         }
     }
 
-    /// <summary>
-    /// Releases the underlying <see cref="HttpClient"/> and any associated resources.
-    /// </summary>
+    /// <summary>Releases the underlying <see cref="HttpClient"/> if owned by this instance.</summary>
     public void Dispose()
     {
         if (_ownsHttpClient)

--- a/Services/IFanService.cs
+++ b/Services/IFanService.cs
@@ -2,57 +2,26 @@ using UglyClient.Models;
 
 namespace UglyClient.Services;
 
-/// <summary>
-/// Defines the contract for all fan-related operations against the environment simulation API.
-/// Implementations must encapsulate every HTTP call and all fan-related error handling so that
-/// no <see cref="System.Net.Http.HttpClient"/> usage for fans exists outside this service.
-/// </summary>
+/// <summary>Contract for all fan-related operations against the simulation API.</summary>
 public interface IFanService
 {
-    /// <summary>
-    /// Sends a POST request to turn a single fan on or off.
-    /// </summary>
-    /// <param name="fanId">The one-based identifier of the fan to control.</param>
-    /// <param name="isOn"><c>true</c> to switch the fan on; <c>false</c> to switch it off.</param>
-    /// <returns>A <see cref="Task"/> that completes when the API acknowledges the command.</returns>
-    /// <exception cref="DeviceServiceException">
-    /// Thrown when the fan update cannot be completed successfully.
-    /// </exception>
+    /// <summary>Turns a single fan on or off.</summary>
+    /// <param name="fanId">One-based fan identifier.</param>
+    /// <param name="isOn"><c>true</c> to switch on; <c>false</c> to switch off.</param>
+    /// <exception cref="DeviceServiceException">Thrown when the update fails.</exception>
     Task SetFanStateAsync(int fanId, bool isOn);
 
-    /// <summary>
-    /// Sends a GET request to retrieve the current on/off state of a single fan.
-    /// </summary>
-    /// <param name="fanId">The one-based identifier of the fan to query.</param>
-    /// <returns>
-    /// A <see cref="Task{FanDTO}"/> whose result is the <see cref="FanDTO"/>
-    /// describing the fan's current state.
-    /// </returns>
-    /// <exception cref="DeviceServiceException">
-    /// Thrown when the fan state cannot be retrieved successfully.
-    /// </exception>
+    /// <summary>Retrieves the current on/off state of a single fan.</summary>
+    /// <param name="fanId">One-based fan identifier.</param>
+    /// <exception cref="DeviceServiceException">Thrown when the state cannot be retrieved.</exception>
     Task<FanDTO> GetFanStateAsync(int fanId);
 
-    /// <summary>
-    /// Sets every managed fan to the same on/off state by calling
-    /// <see cref="SetFanStateAsync"/> for each fan in sequence.
-    /// </summary>
-    /// <param name="isOn"><c>true</c> to switch all fans on; <c>false</c> to switch them all off.</param>
-    /// <returns>A <see cref="Task"/> that completes when all fans have been updated.</returns>
-    /// <exception cref="DeviceServiceException">
-    /// Thrown when any individual fan update cannot be completed successfully.
-    /// </exception>
+    /// <summary>Sets every managed fan to the same on/off state.</summary>
+    /// <param name="isOn"><c>true</c> to switch all fans on; <c>false</c> to switch all off.</param>
+    /// <exception cref="DeviceServiceException">Thrown when any individual fan update fails.</exception>
     Task SetAllFansAsync(bool isOn);
 
-    /// <summary>
-    /// Retrieves the current on/off state of every managed fan.
-    /// </summary>
-    /// <returns>
-    /// A <see cref="Task{T}"/> whose result is an <see cref="IEnumerable{FanDTO}"/>
-    /// containing one <see cref="FanDTO"/> per fan, ordered by ascending fan ID.
-    /// </returns>
-    /// <exception cref="DeviceServiceException">
-    /// Thrown when any individual fan state cannot be retrieved successfully.
-    /// </exception>
+    /// <summary>Retrieves the current on/off state of every managed fan.</summary>
+    /// <exception cref="DeviceServiceException">Thrown when any individual fan state cannot be retrieved.</exception>
     Task<IEnumerable<FanDTO>> GetAllFanStatesAsync();
 }

--- a/Services/IHeaterService.cs
+++ b/Services/IHeaterService.cs
@@ -1,56 +1,26 @@
 namespace UglyClient.Services;
 
-/// <summary>
-/// Defines the contract for all heater-related operations against the environment simulation API.
-/// Implementations must encapsulate every HTTP call and all heater-related error handling so that
-/// no <see cref="System.Net.Http.HttpClient"/> usage for heaters exists outside this service.
-/// </summary>
+/// <summary>Contract for all heater-related operations against the simulation API.</summary>
 public interface IHeaterService
 {
-    /// <summary>
-    /// Sends a POST request to set the heat level of a single heater.
-    /// </summary>
-    /// <param name="heaterId">The one-based identifier of the heater to control.</param>
-    /// <param name="level">The desired heat level (0–5, where 0 is off).</param>
-    /// <returns>A <see cref="Task"/> that completes when the API acknowledges the command.</returns>
-    /// <exception cref="DeviceServiceException">
-    /// Thrown when the heater update cannot be completed successfully.
-    /// </exception>
+    /// <summary>Sets the heat level of a single heater.</summary>
+    /// <param name="heaterId">One-based heater identifier.</param>
+    /// <param name="level">Desired heat level (0–5, where 0 is off).</param>
+    /// <exception cref="DeviceServiceException">Thrown when the update fails.</exception>
     Task SetHeaterLevelAsync(int heaterId, int level);
 
-    /// <summary>
-    /// Sends a GET request to retrieve the current heat level of a single heater.
-    /// </summary>
-    /// <param name="heaterId">The one-based identifier of the heater to query.</param>
-    /// <returns>
-    /// A <see cref="Task{T}"/> whose result is the current heat level (0–5) as an
-    /// <see cref="int"/>.
-    /// </returns>
-    /// <exception cref="DeviceServiceException">
-    /// Thrown when the heater level cannot be retrieved successfully.
-    /// </exception>
+    /// <summary>Retrieves the current heat level of a single heater.</summary>
+    /// <param name="heaterId">One-based heater identifier.</param>
+    /// <returns>Current heat level (0–5).</returns>
+    /// <exception cref="DeviceServiceException">Thrown when the level cannot be retrieved.</exception>
     Task<int> GetHeaterLevelAsync(int heaterId);
 
-    /// <summary>
-    /// Sets every managed heater to the same level by calling
-    /// <see cref="SetHeaterLevelAsync"/> for each heater in sequence.
-    /// </summary>
-    /// <param name="level">The heat level to apply to all heaters (0–5).</param>
-    /// <returns>A <see cref="Task"/> that completes when all heaters have been updated.</returns>
-    /// <exception cref="DeviceServiceException">
-    /// Thrown when any individual heater update cannot be completed successfully.
-    /// </exception>
+    /// <summary>Sets every managed heater to the same level.</summary>
+    /// <param name="level">Heat level to apply to all heaters (0–5).</param>
+    /// <exception cref="DeviceServiceException">Thrown when any individual heater update fails.</exception>
     Task SetAllHeatersAsync(int level);
 
-    /// <summary>
-    /// Retrieves the current heat level of every managed heater.
-    /// </summary>
-    /// <returns>
-    /// A <see cref="Task{T}"/> whose result is an <see cref="IEnumerable{T}"/> of
-    /// <see cref="int"/> values, one per heater, ordered by ascending heater ID.
-    /// </returns>
-    /// <exception cref="DeviceServiceException">
-    /// Thrown when any individual heater level cannot be retrieved successfully.
-    /// </exception>
+    /// <summary>Retrieves the current heat level of every managed heater.</summary>
+    /// <exception cref="DeviceServiceException">Thrown when any individual heater level cannot be retrieved.</exception>
     Task<IEnumerable<int>> GetAllHeaterLevelsAsync();
 }

--- a/Services/IHttpService.cs
+++ b/Services/IHttpService.cs
@@ -1,31 +1,16 @@
 namespace UglyClient.Services;
 
-/// <summary>
-/// Defines the contract for the shared HTTP communication layer used by all service classes.
-/// Implementing classes are responsible for owning and configuring the underlying HTTP client,
-/// including base URL and API key injection.
-/// </summary>
+/// <summary>Contract for the shared HTTP communication layer used by all service classes.</summary>
 public interface IHttpService
 {
-    /// <summary>
-    /// Sends an HTTP GET request to the specified endpoint and returns the response body as a string.
-    /// </summary>
-    /// <param name="endpoint">The relative endpoint path (e.g. "api/fans/1").</param>
-    /// <returns>The response content as a raw string.</returns>
-    /// <exception cref="DeviceServiceException">
-    /// Thrown when the request cannot be completed successfully.
-    /// </exception>
+    /// <summary>Sends a GET request and returns the response body as a string.</summary>
+    /// <param name="endpoint">Relative endpoint path (e.g. <c>api/fans/1</c>).</param>
+    /// <exception cref="DeviceServiceException">Thrown when the request fails.</exception>
     Task<string> GetAsync(string endpoint);
 
-    /// <summary>
-    /// Sends an HTTP POST request to the specified endpoint with the supplied JSON body,
-    /// and returns the response body as a string.
-    /// </summary>
-    /// <param name="endpoint">The relative endpoint path (e.g. "api/fans/1/state").</param>
-    /// <param name="body">The JSON-serialised request body to send.</param>
-    /// <returns>The response content as a raw string.</returns>
-    /// <exception cref="DeviceServiceException">
-    /// Thrown when the request cannot be completed successfully.
-    /// </exception>
+    /// <summary>Sends a POST request with <paramref name="body"/> and returns the response body.</summary>
+    /// <param name="endpoint">Relative endpoint path (e.g. <c>api/fans/1/state</c>).</param>
+    /// <param name="body">JSON-serialised request body.</param>
+    /// <exception cref="DeviceServiceException">Thrown when the request fails.</exception>
     Task<string> PostAsync(string endpoint, string body);
 }

--- a/Services/ISensorService.cs
+++ b/Services/ISensorService.cs
@@ -1,34 +1,14 @@
 namespace UglyClient.Services;
 
-/// <summary>
-/// Defines the facade contract for sensor-related temperature retrieval.
-/// Implementations hide adapter selection and aggregation details behind a small
-/// domain-focused API that always returns temperatures as <see cref="double"/>.
-/// </summary>
+/// <summary>Contract for sensor temperature retrieval.</summary>
 public interface ISensorService
 {
-    /// <summary>
-    /// Retrieves the current temperature from the sensor identified by <paramref name="sensorId"/>.
-    /// </summary>
-    /// <param name="sensorId">The one-based identifier of the sensor to query.</param>
-    /// <returns>
-    /// A <see cref="Task{TResult}"/> that resolves to the current sensor temperature as a
-    /// normalised <see cref="double"/>.
-    /// </returns>
-    /// <exception cref="DeviceServiceException">
-    /// Thrown when the requested sensor reading cannot be retrieved successfully.
-    /// </exception>
+    /// <summary>Retrieves the current temperature from a single sensor.</summary>
+    /// <param name="sensorId">One-based sensor identifier.</param>
+    /// <exception cref="DeviceServiceException">Thrown when the reading cannot be retrieved.</exception>
     Task<double> GetTemperatureAsync(int sensorId);
 
-    /// <summary>
-    /// Retrieves the current temperature from every managed sensor and returns the arithmetic mean.
-    /// </summary>
-    /// <returns>
-    /// A <see cref="Task{TResult}"/> that resolves to the average temperature across all sensors
-    /// as a normalised <see cref="double"/>.
-    /// </returns>
-    /// <exception cref="DeviceServiceException">
-    /// Thrown when one or more sensor readings cannot be retrieved successfully.
-    /// </exception>
+    /// <summary>Retrieves the arithmetic mean of all managed sensor readings.</summary>
+    /// <exception cref="DeviceServiceException">Thrown when one or more readings cannot be retrieved.</exception>
     Task<double> GetAverageTemperatureAsync();
 }

--- a/Services/ISimulationService.cs
+++ b/Services/ISimulationService.cs
@@ -1,26 +1,14 @@
 namespace UglyClient.Services;
 
-/// <summary>
-/// Defines the contract for simulation-wide operations against the environment API.
-/// </summary>
+/// <summary>Contract for simulation-wide operations against the environment API.</summary>
 public interface ISimulationService
 {
-    /// <summary>
-    /// Runs the end-to-end temperature-control cycle.
-    /// </summary>
-    /// <param name="ct">The token used to cancel the cycle cleanly.</param>
-    /// <returns>A <see cref="Task"/> that completes when the cycle finishes or is cancelled.</returns>
-    /// <exception cref="DeviceServiceException">
-    /// Thrown when a device operation fails during the cycle.
-    /// </exception>
+    /// <summary>Runs the end-to-end temperature-control cycle.</summary>
+    /// <param name="ct">Token used to cancel the cycle cleanly.</param>
+    /// <exception cref="DeviceServiceException">Thrown when a device operation fails during the cycle.</exception>
     Task RunAsync(CancellationToken ct);
 
-    /// <summary>
-    /// Resets the simulation to its default state.
-    /// </summary>
-    /// <returns>A <see cref="Task"/> that completes when the reset request succeeds.</returns>
-    /// <exception cref="DeviceServiceException">
-    /// Thrown when the reset request cannot be completed successfully.
-    /// </exception>
+    /// <summary>Resets the simulation to its default state.</summary>
+    /// <exception cref="DeviceServiceException">Thrown when the reset request fails.</exception>
     Task ResetAsync();
 }

--- a/Services/SensorService.cs
+++ b/Services/SensorService.cs
@@ -2,25 +2,12 @@ using UglyClient.Interfaces;
 
 namespace UglyClient.Services;
 
-/// <summary>
-/// Facade implementation of <see cref="ISensorService"/> that delegates temperature reads to the
-/// injected sensor adapters and exposes a unified <see cref="double"/>-based API.
-/// This class contains retrieval and aggregation only; it does not apply any business rules.
-/// </summary>
+/// <summary>Facade implementation of <see cref="ISensorService"/> that delegates to injected sensor adapters.</summary>
 public class SensorService : ISensorService
 {
-    /// <summary>
-    /// Lookup of sensor adapters keyed by their one-based sensor identifier.
-    /// </summary>
     private readonly IReadOnlyDictionary<int, ISensor> _sensorsById;
 
-    /// <summary>
-    /// Initialises a new instance of <see cref="SensorService"/>.
-    /// </summary>
-    /// <param name="sensors">
-    /// The sensor adapters managed by this service. Each adapter must expose a unique
-    /// <see cref="ISensor.SensorId"/> value.
-    /// </param>
+    /// <summary>Initialises a new instance of <see cref="SensorService"/>.</summary>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="sensors"/> is <see langword="null"/>.</exception>
     /// <exception cref="ArgumentException">
     /// Thrown when the sequence is empty, contains a <see langword="null"/> adapter,

--- a/Services/SimulationService.cs
+++ b/Services/SimulationService.cs
@@ -2,26 +2,13 @@ using UglyClient.Controllers;
 
 namespace UglyClient.Services;
 
-/// <summary>
-/// Concrete implementation of <see cref="ISimulationService"/> for simulation-wide API actions.
-/// </summary>
+/// <summary>Concrete implementation of <see cref="ISimulationService"/> for simulation-wide API actions.</summary>
 public sealed class SimulationService : ISimulationService
 {
-    /// <summary>
-    /// The shared HTTP service used to communicate with the simulation API.
-    /// </summary>
     private readonly IHttpService _httpService;
-
-    /// <summary>
-    /// The controller that orchestrates the temperature-control phase cycle.
-    /// </summary>
     private readonly TemperatureController _temperatureController;
 
-    /// <summary>
-    /// Initialises a new instance of <see cref="SimulationService"/>.
-    /// </summary>
-    /// <param name="httpService">The shared HTTP service used for simulation requests.</param>
-    /// <param name="temperatureController">The controller that orchestrates the temperature-control cycle.</param>
+    /// <summary>Initialises a new instance of <see cref="SimulationService"/>.</summary>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="httpService"/> or <paramref name="temperatureController"/> is <see langword="null"/>.
     /// </exception>

--- a/Strategies/CoolDownStrategy.cs
+++ b/Strategies/CoolDownStrategy.cs
@@ -3,49 +3,17 @@ using UglyClient.Services;
 
 namespace UglyClient.Strategies;
 
-/// <summary>
-/// Lowers the environment temperature by disabling heaters and enabling fans until the target is reached
-/// or the allotted duration expires.
-/// </summary>
+/// <summary>Lowers the environment temperature by disabling heaters and enabling fans until the target is reached or duration expires.</summary>
 public class CoolDownStrategy : ITemperatureControlStrategy
 {
-    /// <summary>
-    /// The tolerance used to stop once the target temperature has effectively been reached.
-    /// </summary>
     private const double TemperatureTolerance = 0.1;
-
-    /// <summary>
-    /// The delay between successive temperature polls.
-    /// </summary>
     private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(1);
-
-    /// <summary>
-    /// The heater facade used to stop heating during cool-down.
-    /// </summary>
     private readonly IHeaterService _heaterService;
-
-    /// <summary>
-    /// The fan facade used to increase cooling.
-    /// </summary>
     private readonly IFanService _fanService;
-
-    /// <summary>
-    /// The sensor facade used to poll the current average temperature.
-    /// </summary>
     private readonly ISensorService _sensorService;
-
-    /// <summary>
-    /// The delay operation used between polls.
-    /// </summary>
     private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
 
-    /// <summary>
-    /// Initialises a new instance of <see cref="CoolDownStrategy"/>.
-    /// </summary>
-    /// <param name="heaterService">The heater facade used to control all heaters.</param>
-    /// <param name="fanService">The fan facade used to control all fans.</param>
-    /// <param name="sensorService">The sensor facade used to read temperatures.</param>
-    /// <param name="delayAsync">The delay operation used between temperature polls.</param>
+    /// <summary>Initialises a new instance of <see cref="CoolDownStrategy"/>.</summary>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="heaterService"/>, <paramref name="fanService"/>, or
     /// <paramref name="sensorService"/> is <see langword="null"/>.
@@ -89,15 +57,6 @@ public class CoolDownStrategy : ITemperatureControlStrategy
         return currentTemperature;
     }
 
-    /// <summary>
-    /// Determines whether the cool-down phase can stop because the target has been reached.
-    /// </summary>
-    /// <param name="currentTemperature">The latest observed temperature.</param>
-    /// <param name="targetTemperature">The target temperature for the phase.</param>
-    /// <returns>
-    /// <see langword="true"/> when the temperature is within tolerance of the target or already below it;
-    /// otherwise <see langword="false"/>.
-    /// </returns>
     private static bool HasReachedTarget(double currentTemperature, double targetTemperature)
     {
         return currentTemperature <= targetTemperature ||

--- a/Strategies/HeatUpStrategy.cs
+++ b/Strategies/HeatUpStrategy.cs
@@ -3,54 +3,18 @@ using UglyClient.Services;
 
 namespace UglyClient.Strategies;
 
-/// <summary>
-/// Raises the environment temperature by enabling heaters and disabling fans until the target is reached
-/// or the allotted duration expires.
-/// </summary>
+/// <summary>Raises the environment temperature by enabling heaters and disabling fans until the target is reached or duration expires.</summary>
 public class HeatUpStrategy : ITemperatureControlStrategy
 {
-    /// <summary>
-    /// The heater level applied while heating the environment.
-    /// </summary>
     private const int HeatingLevel = 3;
-
-    /// <summary>
-    /// The tolerance used to stop once the target temperature has effectively been reached.
-    /// </summary>
     private const double TemperatureTolerance = 0.1;
-
-    /// <summary>
-    /// The delay between successive temperature polls.
-    /// </summary>
     private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(1);
-
-    /// <summary>
-    /// The heater facade used to apply heat.
-    /// </summary>
     private readonly IHeaterService _heaterService;
-
-    /// <summary>
-    /// The fan facade used to reduce cooling while heating.
-    /// </summary>
     private readonly IFanService _fanService;
-
-    /// <summary>
-    /// The sensor facade used to poll the current average temperature.
-    /// </summary>
     private readonly ISensorService _sensorService;
-
-    /// <summary>
-    /// The delay operation used between polls.
-    /// </summary>
     private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
 
-    /// <summary>
-    /// Initialises a new instance of <see cref="HeatUpStrategy"/>.
-    /// </summary>
-    /// <param name="heaterService">The heater facade used to control all heaters.</param>
-    /// <param name="fanService">The fan facade used to control all fans.</param>
-    /// <param name="sensorService">The sensor facade used to read temperatures.</param>
-    /// <param name="delayAsync">The delay operation used between temperature polls.</param>
+    /// <summary>Initialises a new instance of <see cref="HeatUpStrategy"/>.</summary>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="heaterService"/>, <paramref name="fanService"/>, or
     /// <paramref name="sensorService"/> is <see langword="null"/>.
@@ -94,15 +58,6 @@ public class HeatUpStrategy : ITemperatureControlStrategy
         return currentTemperature;
     }
 
-    /// <summary>
-    /// Determines whether the heat-up phase can stop because the target has been reached.
-    /// </summary>
-    /// <param name="currentTemperature">The latest observed temperature.</param>
-    /// <param name="targetTemperature">The target temperature for the phase.</param>
-    /// <returns>
-    /// <see langword="true"/> when the temperature is within tolerance of the target or already above it;
-    /// otherwise <see langword="false"/>.
-    /// </returns>
     private static bool HasReachedTarget(double currentTemperature, double targetTemperature)
     {
         return currentTemperature >= targetTemperature ||

--- a/Strategies/HoldStrategy.cs
+++ b/Strategies/HoldStrategy.cs
@@ -3,55 +3,18 @@ using UglyClient.Services;
 
 namespace UglyClient.Strategies;
 
-/// <summary>
-/// Maintains the environment temperature near a target by applying small corrective changes and
-/// polling the average temperature once per second.
-/// </summary>
+/// <summary>Maintains the environment temperature near a target by applying small corrective changes each second.</summary>
 public class HoldStrategy : ITemperatureControlStrategy
 {
-    /// <summary>
-    /// The heater level applied while correcting a temperature that is below the target.
-    /// </summary>
     private const int MinimalHeatingLevel = 1;
-
-    /// <summary>
-    /// The tolerance band (in degrees Celsius) within which no corrective device calls are made.
-    /// Deviations smaller than this value are ignored to prevent micro-oscillation.
-    /// </summary>
     private const double TemperatureTolerance = 0.1;
-
-    /// <summary>
-    /// The delay between successive temperature polls.
-    /// </summary>
     private static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(1);
-
-    /// <summary>
-    /// The heater facade used to apply corrective heating.
-    /// </summary>
     private readonly IHeaterService _heaterService;
-
-    /// <summary>
-    /// The fan facade used to apply corrective cooling.
-    /// </summary>
     private readonly IFanService _fanService;
-
-    /// <summary>
-    /// The sensor facade used to poll the current average temperature.
-    /// </summary>
     private readonly ISensorService _sensorService;
-
-    /// <summary>
-    /// The delay operation used between polls.
-    /// </summary>
     private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync;
 
-    /// <summary>
-    /// Initialises a new instance of <see cref="HoldStrategy"/>.
-    /// </summary>
-    /// <param name="heaterService">The heater facade used to control all heaters.</param>
-    /// <param name="fanService">The fan facade used to control all fans.</param>
-    /// <param name="sensorService">The sensor facade used to read temperatures.</param>
-    /// <param name="delayAsync">The delay operation used between temperature polls.</param>
+    /// <summary>Initialises a new instance of <see cref="HoldStrategy"/>.</summary>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="heaterService"/>, <paramref name="fanService"/>, or
     /// <paramref name="sensorService"/> is <see langword="null"/>.

--- a/UI/MenuController.cs
+++ b/UI/MenuController.cs
@@ -10,12 +10,19 @@ namespace UglyClient.UI;
 /// </summary>
 public sealed class MenuController
 {
+    /// <summary>Fan control service.</summary>
     private readonly IFanService _fanService;
+    /// <summary>Heater control service.</summary>
     private readonly IHeaterService _heaterService;
+    /// <summary>Sensor read service.</summary>
     private readonly ISensorService _sensorService;
+    /// <summary>Simulation lifecycle service.</summary>
     private readonly ISimulationService _simulationService;
+    /// <summary>Simulation configuration (used for device counts and validation).</summary>
     private readonly SimulationConfig _config;
+    /// <summary>Reader for user input.</summary>
     private readonly TextReader _input;
+    /// <summary>Writer for program output.</summary>
     private readonly TextWriter _output;
 
     /// <summary>


### PR DESCRIPTION
## Summary

Closes #17

### Changes

**Documentation – condensed to one-liners throughout (no AI slop):**
- `Models/FanDTO.cs` — trimmed verbose property summaries to `"Fan identifier."` / `"true if on; false if off."`
- `Config/SimulationConfig.cs` — condensed class summary, removed verbose `<remarks>` block
- `Interfaces/ISensor.cs` — condensed class summary, removed verbose `<returns>` on `GetTemperatureAsync`
- `Interfaces/ITemperatureControlStrategy.cs` — condensed class summary and `<param>` tags
- `Services/IHttpService.cs`, `IFanService.cs`, `IHeaterService.cs`, `ISensorService.cs`, `ISimulationService.cs` — condensed verbose class summaries and method docs
- `Services/HttpService.cs` — condensed class summary; **removed** XML docs from all private fields and private `SendAsync` method
- `Services/FanService.cs`, `HeaterService.cs`, `SensorService.cs`, `SimulationService.cs` — condensed class summaries; removed private field docs
- `Adapters/Sensor1Adapter.cs`, `Sensor2Adapter.cs`, `Sensor3Adapter.cs` — condensed class summaries, constructor docs, property docs; trimmed `<remarks>` on `GetTemperatureAsync`
- `Strategies/HeatUpStrategy.cs`, `CoolDownStrategy.cs`, `HoldStrategy.cs` — condensed class summaries; **removed** docs from all private fields/constants; removed verbose `HasReachedTarget` docs
- `Controllers/TemperatureController.cs` — condensed class summary; removed private field docs; trimmed constructor and method docs
- `UI/MenuController.cs` — **added** `/// <summary>` to all 7 private fields (required by spec)

### Verification
- `dotnet build` → **0 warnings, 0 errors**
- `dotnet test` → **122/122 passed**